### PR TITLE
feat: add mock data generators for all ZMQ channels

### DIFF
--- a/demo/mock_detections.py
+++ b/demo/mock_detections.py
@@ -1,0 +1,148 @@
+"""Mock detection generator — publishes DetectionOutput JSON to ZMQ port 5556.
+
+Usage:
+    python demo/mock_detections.py
+    python demo/mock_detections.py --frames 50 --poi-density 5 --fps 5
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+
+import zmq
+
+# Ensure the package is importable when run from repo root
+sys.path.insert(0, "src")
+
+from breacheye.rafa.schemas import BBox2D, Detection, DetectionOutput
+
+# Frame dimensions
+FRAME_W = 960
+FRAME_H = 720
+
+POI_LABEL_MAP: dict[str, str] = {
+    "T1-01": "Entry/Exit Point",
+    "T1-02": "Fatal Funnel",
+    "T1-03": "Stairs/Vertical",
+    "T2-02": "Threat Indicator",
+    "T2-03": "Chokepoint",
+    "T3-01": "Utility Panel",
+    "T4-01": "Structural Damage",
+    "ROOM": "Room/Open Area",
+}
+
+# Threat levels weighted toward lower severity for realism
+THREAT_WEIGHTS = {
+    "HOT": 0.05,
+    "WARM": 0.15,
+    "CAUTION": 0.30,
+    "CLEAR": 0.35,
+    "INFO": 0.15,
+}
+
+CATEGORIES = list(POI_LABEL_MAP.keys())
+THREAT_LEVELS = list(THREAT_WEIGHTS.keys())
+THREAT_PROBS = list(THREAT_WEIGHTS.values())
+
+# Description templates per category
+DESCRIPTIONS: dict[str, list[str]] = {
+    "T1-01": ["Door frame visible", "Opening detected", "Threshold identified"],
+    "T1-02": ["Narrow passage ahead", "Funnel geometry detected", "High-exposure corridor"],
+    "T1-03": ["Staircase structure", "Vertical transition point", "Elevation change"],
+    "T2-02": ["Potential hostile indicator", "Anomalous object", "Threat marker"],
+    "T2-03": ["Bottleneck geometry", "Single file passage", "Tactical chokepoint"],
+    "T3-01": ["Electrical panel", "Utility access point", "Infrastructure node"],
+    "T4-01": ["Structural compromise", "Debris field", "Wall breach"],
+    "ROOM": ["Open area cleared", "Room boundary detected", "Space mapped"],
+}
+
+
+def random_bbox() -> BBox2D:
+    """Generate a random plausible bounding box within 960x720."""
+    # Minimum size 40px, maximum 300px per dimension
+    w = random.randint(40, 300)
+    h = random.randint(40, 250)
+    x1 = random.randint(0, FRAME_W - w - 1)
+    y1 = random.randint(0, FRAME_H - h - 1)
+    return BBox2D(x1=x1, y1=y1, x2=x1 + w, y2=y1 + h)
+
+
+def generate_frame(frame_id: int, max_detections: int) -> DetectionOutput:
+    """Generate one DetectionOutput with 0..max_detections detections."""
+    # ~20% of frames have zero detections
+    n = 0 if random.random() < 0.20 else random.randint(1, max_detections)
+
+    detections: list[Detection] = []
+    for idx in range(n):
+        category = random.choice(CATEGORIES)
+        threat_level = random.choices(THREAT_LEVELS, weights=THREAT_PROBS, k=1)[0]
+        confidence = round(random.uniform(0.40, 0.95), 3)
+        description = random.choice(DESCRIPTIONS[category])
+
+        det = Detection(
+            id=f"det-{frame_id:03d}-{idx:03d}",
+            category=category,
+            label=POI_LABEL_MAP[category],
+            description=description,
+            confidence=confidence,
+            bbox_2d=random_bbox(),
+            threat_level=threat_level,
+            detection_model="moondream",
+        )
+        detections.append(det)
+
+    processing_ms = random.randint(15, 35)
+    return DetectionOutput(
+        frame_id=frame_id,
+        timestamp=time.time(),
+        detections=detections,
+        processing_ms=processing_ms,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish mock DetectionOutput to ZMQ port 5556")
+    parser.add_argument("--frames", type=int, default=100, help="Number of frames to publish (default: 100)")
+    parser.add_argument("--poi-density", type=int, default=3, help="Max detections per frame (default: 3)")
+    parser.add_argument("--fps", type=float, default=10.0, help="Publish rate in frames per second (default: 10)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    interval = 1.0 / args.fps
+
+    context = zmq.Context()
+    socket = context.socket(zmq.PUB)
+    socket.bind("tcp://*:5556")
+
+    print(f"[mock_detections] Starting — frames={args.frames}, poi_density={args.poi_density}, fps={args.fps}")
+    print(f"[mock_detections] Publishing to tcp://*:5556")
+    # Brief sleep so subscribers can connect before first message
+    time.sleep(0.5)
+
+    try:
+        for frame_id in range(args.frames):
+            output = generate_frame(frame_id, args.poi_density)
+            payload = json.dumps(output.model_dump())
+            socket.send_string(payload)
+
+            if frame_id % 10 == 0:
+                det_count = len(output.detections)
+                print(f"[mock_detections] frame={frame_id:03d}  detections={det_count}")
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        print("\n[mock_detections] Interrupted — shutting down")
+    finally:
+        socket.close()
+        context.term()
+        print("[mock_detections] Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/mock_navigation.py
+++ b/demo/mock_navigation.py
@@ -1,0 +1,268 @@
+"""Mock navigation generator — publishes NavigationOutput JSON to ZMQ port 5558.
+
+Usage:
+    python demo/mock_navigation.py
+    python demo/mock_navigation.py --frames 50 --pattern corridor_follow --fps 2
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+
+import zmq
+
+sys.path.insert(0, "src")
+
+from breacheye.rafa.schemas import NavigationDecision, NavigationOutput
+
+# ── Pattern definitions ──────────────────────────────────────────────────────
+
+# room_sweep: systematic rotation then forward movement
+ROOM_SWEEP_CYCLE = [
+    "rotate_right",
+    "rotate_right",
+    "rotate_right",
+    "rotate_right",
+    "move_forward",
+    "move_forward",
+    "rotate_left",
+    "rotate_left",
+    "rotate_left",
+    "rotate_left",
+    "move_forward",
+    "hover",
+]
+
+# corridor_follow: mostly forward with occasional turns
+CORRIDOR_FOLLOW_WEIGHTS = {
+    "move_forward": 0.55,
+    "rotate_left": 0.10,
+    "rotate_right": 0.10,
+    "move_up": 0.05,
+    "move_down": 0.05,
+    "hover": 0.10,
+    "move_back": 0.05,
+}
+
+# random_explore: uniform over all actions except land
+RANDOM_ACTIONS = [
+    "move_forward",
+    "move_back",
+    "move_left",
+    "move_right",
+    "move_up",
+    "move_down",
+    "rotate_left",
+    "rotate_right",
+    "hover",
+]
+
+REASONING_MAP: dict[str, list[str]] = {
+    "move_forward": [
+        "Clear path ahead — advancing",
+        "No obstacles detected — continuing forward",
+        "Open corridor — pushing forward",
+    ],
+    "move_back": [
+        "Backing away from obstacle",
+        "Retreating to improve angle",
+        "Collision risk — reversing",
+    ],
+    "move_left": [
+        "Sweeping left quadrant",
+        "Lateral shift for coverage",
+        "Avoiding detected obstacle on right",
+    ],
+    "move_right": [
+        "Sweeping right quadrant",
+        "Lateral shift for coverage",
+        "Avoiding detected obstacle on left",
+    ],
+    "move_up": [
+        "Gaining altitude for overview",
+        "Clearing ground-level obstruction",
+        "Ascending to map upper zone",
+    ],
+    "move_down": [
+        "Descending for detail capture",
+        "Lowering altitude to inspect POI",
+        "Reducing elevation for passage",
+    ],
+    "rotate_left": [
+        "Scanning left sector",
+        "Turning to investigate left flank",
+        "Coverage sweep — rotating left",
+    ],
+    "rotate_right": [
+        "Scanning right sector",
+        "Turning to investigate right flank",
+        "Coverage sweep — rotating right",
+    ],
+    "hover": [
+        "Holding position for analysis",
+        "Stationary capture for keyframe",
+        "Pausing — processing detections",
+    ],
+    "land": [
+        "Mission complete — landing",
+        "Low battery — initiating landing",
+    ],
+}
+
+# Exploration state progression weights (transitions are frame-by-frame probabilistic)
+# Format: {current_state: {next_state: probability}}
+STATE_TRANSITIONS: dict[str, dict[str, float]] = {
+    "exploring": {
+        "exploring": 0.75,
+        "investigating_poi": 0.15,
+        "obstacle_avoidance": 0.07,
+        "coverage_complete": 0.03,
+    },
+    "investigating_poi": {
+        "investigating_poi": 0.50,
+        "exploring": 0.40,
+        "obstacle_avoidance": 0.10,
+    },
+    "obstacle_avoidance": {
+        "obstacle_avoidance": 0.40,
+        "exploring": 0.55,
+        "returning": 0.05,
+    },
+    "coverage_complete": {
+        "coverage_complete": 0.70,
+        "returning": 0.30,
+    },
+    "returning": {
+        "returning": 0.80,
+        "exploring": 0.20,
+    },
+    "low_battery": {
+        "low_battery": 0.90,
+        "returning": 0.10,
+    },
+}
+
+
+def next_state(current: str, frame_id: int, total_frames: int) -> str:
+    """Transition exploration state probabilistically; force low_battery near end."""
+    # Force low_battery in the last 10% of frames
+    if frame_id >= int(total_frames * 0.90) and current not in ("low_battery", "returning"):
+        return "low_battery"
+
+    transitions = STATE_TRANSITIONS.get(current, {"exploring": 1.0})
+    states = list(transitions.keys())
+    probs = list(transitions.values())
+    return random.choices(states, weights=probs, k=1)[0]
+
+
+def room_sweep_action(frame_id: int) -> str:
+    return ROOM_SWEEP_CYCLE[frame_id % len(ROOM_SWEEP_CYCLE)]
+
+
+def corridor_follow_action() -> str:
+    actions = list(CORRIDOR_FOLLOW_WEIGHTS.keys())
+    weights = list(CORRIDOR_FOLLOW_WEIGHTS.values())
+    return random.choices(actions, weights=weights, k=1)[0]
+
+
+def random_explore_action() -> str:
+    return random.choice(RANDOM_ACTIONS)
+
+
+def generate_frame(
+    frame_id: int,
+    pattern: str,
+    total_frames: int,
+    current_state: str,
+) -> tuple[NavigationOutput, str]:
+    """Return (NavigationOutput, new_exploration_state)."""
+    if pattern == "room_sweep":
+        action = room_sweep_action(frame_id)
+    elif pattern == "corridor_follow":
+        action = corridor_follow_action()
+    else:
+        action = random_explore_action()
+
+    # State may be overridden to match action context
+    exp_state = next_state(current_state, frame_id, total_frames)
+
+    # If in low_battery or returning, prefer hover/back actions
+    if exp_state in ("low_battery", "returning") and pattern != "room_sweep":
+        action = random.choices(
+            ["hover", "move_back", "rotate_left", "rotate_right"],
+            weights=[0.50, 0.30, 0.10, 0.10],
+            k=1,
+        )[0]
+
+    confidence = round(random.uniform(0.30, 0.95), 3)
+    reasoning = random.choice(REASONING_MAP.get(action, ["Executing action"]))
+
+    decision = NavigationDecision(
+        action=action,
+        params={},
+        confidence=confidence,
+        reasoning=reasoning,
+        exploration_state=exp_state,
+    )
+    output = NavigationOutput(
+        frame_id=frame_id,
+        timestamp=time.time(),
+        decision=decision,
+    )
+    return output, exp_state
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish mock NavigationOutput to ZMQ port 5558")
+    parser.add_argument("--frames", type=int, default=100, help="Number of frames to publish (default: 100)")
+    parser.add_argument(
+        "--pattern",
+        choices=["room_sweep", "corridor_follow", "random_explore"],
+        default="room_sweep",
+        help="Navigation pattern to simulate (default: room_sweep)",
+    )
+    parser.add_argument("--fps", type=float, default=2.0, help="Publish rate in frames per second (default: 2)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    interval = 1.0 / args.fps
+
+    context = zmq.Context()
+    socket = context.socket(zmq.PUB)
+    socket.bind("tcp://*:5558")
+
+    print(f"[mock_navigation] Starting — frames={args.frames}, pattern={args.pattern}, fps={args.fps}")
+    print(f"[mock_navigation] Publishing to tcp://*:5558")
+    time.sleep(0.5)
+
+    current_state = "exploring"
+    try:
+        for frame_id in range(args.frames):
+            output, current_state = generate_frame(frame_id, args.pattern, args.frames, current_state)
+            payload = json.dumps(output.model_dump())
+            socket.send_string(payload)
+
+            if frame_id % 10 == 0:
+                d = output.decision
+                print(
+                    f"[mock_navigation] frame={frame_id:03d}  "
+                    f"action={d.action:<16s}  state={d.exploration_state:<20s}  conf={d.confidence:.2f}"
+                )
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        print("\n[mock_navigation] Interrupted — shutting down")
+    finally:
+        socket.close()
+        context.term()
+        print("[mock_navigation] Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/mock_navigation.py
+++ b/demo/mock_navigation.py
@@ -112,6 +112,20 @@ REASONING_MAP: dict[str, list[str]] = {
     ],
 }
 
+MOVE_ACTIONS = {"move_forward", "move_back", "move_left", "move_right", "move_up", "move_down"}
+ROTATE_ACTIONS = {"rotate_left", "rotate_right"}
+
+
+def params_for_action(action: str) -> dict[str, int | float | str]:
+    if action in MOVE_ACTIONS:
+        return {"distance_cm": random.randint(20, 50)}
+    if action in ROTATE_ACTIONS:
+        return {"degrees": random.randint(15, 90)}
+    if action == "hover":
+        return {"duration_ms": random.randint(500, 2000)}
+    return {}
+
+
 # Exploration state progression weights (transitions are frame-by-frame probabilistic)
 # Format: {current_state: {next_state: probability}}
 STATE_TRANSITIONS: dict[str, dict[str, float]] = {
@@ -200,9 +214,16 @@ def generate_frame(
     confidence = round(random.uniform(0.30, 0.95), 3)
     reasoning = random.choice(REASONING_MAP.get(action, ["Executing action"]))
 
+    # Final frame always lands
+    if frame_id == total_frames - 1:
+        action = "land"
+        exp_state = "returning"
+        reasoning = random.choice(REASONING_MAP["land"])
+        confidence = 1.0
+
     decision = NavigationDecision(
         action=action,
-        params={},
+        params=params_for_action(action),
         confidence=confidence,
         reasoning=reasoning,
         exploration_state=exp_state,

--- a/demo/mock_telemetry.py
+++ b/demo/mock_telemetry.py
@@ -1,0 +1,143 @@
+"""Mock telemetry generator — publishes HealthOutput JSON to ZMQ port 5559.
+
+Usage:
+    python demo/mock_telemetry.py
+    python demo/mock_telemetry.py --frames 200 --fps 1
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+
+import zmq
+
+sys.path.insert(0, "src")
+
+from breacheye.rafa.schemas import HealthOutput, MemoryStatus, ModelStatus, Throughput
+
+# Model VRAM baselines (MB)
+MODEL_VRAM: dict[str, int] = {
+    "moondream": 1800,
+    "depth_anything_v2": 600,
+    "qwen3_vl": 4200,
+}
+
+# Throughput baselines
+DETECTION_FPS_RANGE = (10.0, 15.0)
+DEPTH_FPS_RANGE = (6.0, 10.0)
+DECISION_FPS_RANGE = (0.5, 1.0)
+
+# Memory baselines
+RAM_USED_RANGE = (8.0, 9.0)
+VRAM_TOTAL_GB = 36.0
+
+# Battery drain: ~0.5% per frame
+BATTERY_START = 100.0
+BATTERY_DRAIN_PER_FRAME = 0.5
+BATTERY_LOW_THRESHOLD = 15.0
+
+
+def jitter(value: float, pct: float = 0.08) -> float:
+    """Apply ±pct fractional jitter to value."""
+    return value * (1.0 + random.uniform(-pct, pct))
+
+
+def generate_frame(frame_id: int, battery_pct: float) -> HealthOutput:
+    """Generate one HealthOutput frame."""
+    degraded = battery_pct < BATTERY_LOW_THRESHOLD
+    pipeline_status = "degraded" if degraded else "ready"
+
+    # VRAM jitter ±2%
+    models_loaded = {
+        name: ModelStatus(
+            status="ready",
+            active=name,
+            vram_mb=int(jitter(base_vram, 0.02)),
+        )
+        for name, base_vram in MODEL_VRAM.items()
+    }
+
+    detection_fps = round(jitter(random.uniform(*DETECTION_FPS_RANGE)), 2)
+    depth_fps = round(jitter(random.uniform(*DEPTH_FPS_RANGE)), 2)
+    decision_fps = round(jitter(random.uniform(*DECISION_FPS_RANGE), 0.12), 3)
+
+    throughput = Throughput(
+        detection_fps=max(0.0, detection_fps),
+        depth_fps=max(0.0, depth_fps),
+        decision_fps=max(0.0, decision_fps),
+    )
+
+    ram_used_gb = round(jitter(random.uniform(*RAM_USED_RANGE), 0.05), 2)
+    memory = MemoryStatus(
+        ram_used_gb=ram_used_gb,
+        vram_total_gb=VRAM_TOTAL_GB,
+    )
+
+    errors: list[str] = []
+    if degraded:
+        errors.append(f"Low battery: {battery_pct:.1f}%")
+
+    return HealthOutput(
+        pipeline_status=pipeline_status,
+        models_loaded=models_loaded,
+        throughput=throughput,
+        memory=memory,
+        errors=errors,
+        timestamp=time.time(),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Publish mock HealthOutput to ZMQ port 5559")
+    parser.add_argument("--frames", type=int, default=100, help="Number of frames to publish (default: 100)")
+    parser.add_argument("--fps", type=float, default=1.0, help="Publish rate in frames per second (default: 1)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    interval = 1.0 / args.fps
+
+    context = zmq.Context()
+    socket = context.socket(zmq.PUB)
+    socket.bind("tcp://*:5559")
+
+    print(f"[mock_telemetry] Starting — frames={args.frames}, fps={args.fps}")
+    print(f"[mock_telemetry] Publishing to tcp://*:5559")
+    print(f"[mock_telemetry] Battery drain: {BATTERY_DRAIN_PER_FRAME}%/frame, low threshold: {BATTERY_LOW_THRESHOLD}%")
+    time.sleep(0.5)
+
+    battery = BATTERY_START
+    try:
+        for frame_id in range(args.frames):
+            battery = max(0.0, battery - BATTERY_DRAIN_PER_FRAME)
+            output = generate_frame(frame_id, battery)
+            payload = json.dumps(output.model_dump())
+            socket.send_string(payload)
+
+            if frame_id % 10 == 0:
+                tp = output.throughput
+                mem = output.memory
+                print(
+                    f"[mock_telemetry] frame={frame_id:03d}  "
+                    f"battery={battery:.1f}%  "
+                    f"status={output.pipeline_status:<8s}  "
+                    f"det_fps={tp.detection_fps:.1f}  "
+                    f"ram={mem.ram_used_gb:.1f}GB"
+                )
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        print("\n[mock_telemetry] Interrupted — shutting down")
+    finally:
+        socket.close()
+        context.term()
+        print("[mock_telemetry] Done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `demo/mock_detections.py` — publishes DetectionOutput JSON to port 5556. All 8 POI categories, realistic bboxes (960x720), weighted threat levels, ~20% empty frames.
- `demo/mock_navigation.py` — publishes NavigationOutput JSON to port 5558. Three patterns: room_sweep (systematic cycle), corridor_follow (weighted forward), random_explore. Logical state transitions, low_battery in final 10%.
- `demo/mock_telemetry.py` — publishes HealthOutput JSON to port 5559. Battery drain 0.5%/frame, throughput jitter, degrades at <15% battery.

All scripts validate against Pydantic schemas in `src/breacheye/rafa/schemas.py`. Configurable via argparse (--frames, --fps, --pattern, --poi-density).

Closes #8.

## Test plan
- [ ] `python demo/mock_detections.py --frames 20 --fps 5` — verify JSON on port 5556
- [ ] `python demo/mock_navigation.py --frames 20 --pattern room_sweep` — verify nav decisions
- [ ] `python demo/mock_telemetry.py --frames 20` — verify battery drain + degraded state
- [ ] Ctrl+C all three — verify clean ZMQ shutdown