### PR TITLE
feat: nav interpreter — semantic actions to DroneCommand (link #6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
+    "httpx>=0.27",
     "pydantic>=2.7",
     "uvicorn[standard]>=0.30",
 ]

--- a/src/breacheye/nav_interpreter.py
+++ b/src/breacheye/nav_interpreter.py
@@ -19,6 +19,7 @@ class NavInterpreter:
         self.command_url = command_url
         self._socket = None
         self._client = None  # httpx.AsyncClient
+        self._poller = None
 
     def start(self) -> None:
         import zmq
@@ -34,21 +35,17 @@ class NavInterpreter:
 
         self._client = httpx.AsyncClient()
 
-    def close(self) -> None:
+        self._poller = zmq.asyncio.Poller()
+        self._poller.register(self._socket, zmq.POLLIN)
+
+    async def aclose(self) -> None:
         if self._socket is not None:
             self._socket.close(linger=0)
             self._socket = None
+        if self._poller is not None:
+            self._poller = None
         if self._client is not None:
-            import asyncio
-
-            try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    loop.create_task(self._client.aclose())
-                else:
-                    loop.run_until_complete(self._client.aclose())
-            except Exception:
-                pass
+            await self._client.aclose()
             self._client = None
 
     async def run_forever(self) -> None:
@@ -59,29 +56,32 @@ class NavInterpreter:
         import zmq
 
         assert self._socket is not None, "call start() before run_once()"
+        assert self._poller is not None, "call start() before run_once()"
 
-        poller = zmq.asyncio.Poller()
-        poller.register(self._socket, zmq.POLLIN)
-        events = await poller.poll(timeout=500)
+        events = await self._poller.poll(timeout=500)
         if not events:
             return False
 
         try:
-            data = self._socket.recv(zmq.NOBLOCK)
+            data = await self._socket.recv(zmq.NOBLOCK)
         except zmq.Again:
             return False
 
-        nav = decode_navigation(data)
-        logger.info(
-            "recv frame=%d action=%s confidence=%.2f",
-            nav.frame_id,
-            nav.decision.action,
-            nav.decision.confidence,
-        )
+        try:
+            nav = decode_navigation(data)
+            logger.info(
+                "recv frame=%d action=%s confidence=%.2f",
+                nav.frame_id,
+                nav.decision.action,
+                nav.decision.confidence,
+            )
 
-        cmd = self._map_action(nav.decision)
-        await self._post_command(cmd)
-        return True
+            cmd = self._map_action(nav.decision)
+            await self._post_command(cmd)
+            return True
+        except Exception:
+            logger.exception("failed to process nav message")
+            return False
 
     def _map_action(self, decision: NavigationDecision) -> DroneCommand:
         if decision.confidence < 0.5:
@@ -101,7 +101,7 @@ class NavInterpreter:
             return cmd
 
         # RC_CONTROL actions
-        speed = int(decision.params.get("speed_cm_s", 30))
+        speed = max(1, min(100, int(decision.params.get("speed_cm_s", 30))))
 
         if action in ("move_up", "move_down"):
             distance = int(decision.params.get("distance_cm", 25))

--- a/src/breacheye/nav_interpreter.py
+++ b/src/breacheye/nav_interpreter.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import logging
+
+from breacheye.models import CommandType, DroneCommand, RCControlPayload
+from breacheye.rafa.codec import decode_navigation
+from breacheye.rafa.schemas import NavigationDecision
+
+logger = logging.getLogger("breacheye.nav_interpreter")
+
+
+class NavInterpreter:
+    def __init__(
+        self,
+        endpoint: str = "tcp://127.0.0.1:5558",
+        command_url: str = "http://localhost:8000/commands",
+    ) -> None:
+        self.endpoint = endpoint
+        self.command_url = command_url
+        self._socket = None
+        self._client = None  # httpx.AsyncClient
+
+    def start(self) -> None:
+        import zmq
+        import zmq.asyncio
+
+        context = zmq.asyncio.Context.instance()
+        self._socket = context.socket(zmq.SUB)
+        self._socket.setsockopt(zmq.SUBSCRIBE, b"")
+        self._socket.setsockopt(zmq.CONFLATE, 1)
+        self._socket.connect(self.endpoint)
+
+        import httpx
+
+        self._client = httpx.AsyncClient()
+
+    def close(self) -> None:
+        if self._socket is not None:
+            self._socket.close(linger=0)
+            self._socket = None
+        if self._client is not None:
+            import asyncio
+
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    loop.create_task(self._client.aclose())
+                else:
+                    loop.run_until_complete(self._client.aclose())
+            except Exception:
+                pass
+            self._client = None
+
+    async def run_forever(self) -> None:
+        while True:
+            await self.run_once()
+
+    async def run_once(self) -> bool:
+        import zmq
+
+        assert self._socket is not None, "call start() before run_once()"
+
+        poller = zmq.asyncio.Poller()
+        poller.register(self._socket, zmq.POLLIN)
+        events = await poller.poll(timeout=500)
+        if not events:
+            return False
+
+        try:
+            data = self._socket.recv(zmq.NOBLOCK)
+        except zmq.Again:
+            return False
+
+        nav = decode_navigation(data)
+        logger.info(
+            "recv frame=%d action=%s confidence=%.2f",
+            nav.frame_id,
+            nav.decision.action,
+            nav.decision.confidence,
+        )
+
+        cmd = self._map_action(nav.decision)
+        await self._post_command(cmd)
+        return True
+
+    def _map_action(self, decision: NavigationDecision) -> DroneCommand:
+        if decision.confidence < 0.5:
+            logger.info("low confidence=%.2f, overriding to hover", decision.confidence)
+            return DroneCommand(type=CommandType.HOVER, issued_by="nav_interpreter")
+
+        action = decision.action
+
+        if action == "hover":
+            cmd = DroneCommand(type=CommandType.HOVER, issued_by="nav_interpreter")
+            logger.info("send type=%s cmd_id=%s", cmd.type, cmd.command_id)
+            return cmd
+
+        if action == "land":
+            cmd = DroneCommand(type=CommandType.LAND, issued_by="nav_interpreter")
+            logger.info("send type=%s cmd_id=%s", cmd.type, cmd.command_id)
+            return cmd
+
+        # RC_CONTROL actions
+        speed = int(decision.params.get("speed_cm_s", 30))
+
+        if action in ("move_up", "move_down"):
+            distance = int(decision.params.get("distance_cm", 25))
+        else:
+            distance = int(decision.params.get("distance_cm", 40))
+
+        if action in ("rotate_left", "rotate_right"):
+            degrees = decision.params.get("degrees", 30)
+            duration_ms = max(100, min(800, int(float(degrees) / 90 * 1000)))
+        else:
+            duration_ms = max(100, min(800, int(distance / max(speed, 1) * 1000)))
+
+        ttl_ms = min(1200, duration_ms + 200)
+
+        vel_map = {
+            "move_forward": {"forward_back": speed},
+            "move_back": {"forward_back": -speed},
+            "move_left": {"left_right": -speed},
+            "move_right": {"left_right": speed},
+            "move_up": {"up_down": speed},
+            "move_down": {"up_down": -speed},
+            "rotate_left": {"yaw": -25},
+            "rotate_right": {"yaw": 25},
+        }
+
+        axes = vel_map[action]
+        payload = RCControlPayload(duration_ms=duration_ms, **axes)
+
+        cmd = DroneCommand(
+            type=CommandType.RC_CONTROL,
+            issued_by="nav_interpreter",
+            ttl_ms=ttl_ms,
+            payload=payload,
+        )
+        logger.info("send type=%s cmd_id=%s", cmd.type, cmd.command_id)
+        return cmd
+
+    async def _post_command(self, cmd: DroneCommand) -> None:
+        assert self._client is not None, "call start() before _post_command()"
+        resp = await self._client.post(self.command_url, json=cmd.model_dump(mode="json"))
+        if resp.status_code != 200:
+            logger.warning("post failed status=%d", resp.status_code)

--- a/tests/test_nav_interpreter.py
+++ b/tests/test_nav_interpreter.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from breacheye.models import CommandType
+from breacheye.nav_interpreter import NavInterpreter
+from breacheye.rafa.schemas import NavigationAction, NavigationDecision
+
+# All NavigationAction literal values
+ALL_ACTIONS: list[NavigationAction] = [
+    "move_forward",
+    "move_back",
+    "move_left",
+    "move_right",
+    "move_up",
+    "move_down",
+    "rotate_left",
+    "rotate_right",
+    "hover",
+    "land",
+]
+
+
+@pytest.fixture
+def interp() -> NavInterpreter:
+    return NavInterpreter()
+
+
+def make_decision(
+    action: NavigationAction,
+    params: dict | None = None,
+    confidence: float = 0.8,
+    exploration_state: str = "exploring",
+) -> NavigationDecision:
+    return NavigationDecision(
+        action=action,
+        params=params or {},
+        confidence=confidence,
+        reasoning="test",
+        exploration_state=exploration_state,
+    )
+
+
+def test_map_forward(interp: NavInterpreter) -> None:
+    decision = make_decision(
+        "move_forward",
+        params={"distance_cm": 50, "speed_cm_s": 30},
+        confidence=0.8,
+    )
+    cmd = interp._map_action(decision)
+
+    assert cmd.type == CommandType.RC_CONTROL
+    assert cmd.issued_by == "nav_interpreter"
+    assert cmd.payload is not None
+    assert cmd.payload.forward_back == 30
+    assert cmd.payload.left_right == 0
+    assert cmd.payload.up_down == 0
+    assert cmd.payload.yaw == 0
+    # 50/30*1000 = 1667, clamped to 800
+    assert cmd.payload.duration_ms == 800
+    assert cmd.ttl_ms == 1000  # min(1200, 800+200)
+
+
+def test_all_actions_produce_valid_commands(interp: NavInterpreter) -> None:
+    for action in ALL_ACTIONS:
+        decision = make_decision(action, confidence=0.8)
+        cmd = interp._map_action(decision)
+
+        assert cmd is not None, f"no command for action={action}"
+        assert cmd.issued_by == "nav_interpreter"
+
+        if action == "hover":
+            assert cmd.type == CommandType.HOVER
+            assert cmd.payload is None
+        elif action == "land":
+            assert cmd.type == CommandType.LAND
+            assert cmd.payload is None
+        else:
+            assert cmd.type == CommandType.RC_CONTROL
+            assert cmd.payload is not None
+
+
+def test_rotate_uses_degrees(interp: NavInterpreter) -> None:
+    decision = make_decision(
+        "rotate_right",
+        params={"degrees": 45},
+        confidence=0.9,
+    )
+    cmd = interp._map_action(decision)
+
+    assert cmd.type == CommandType.RC_CONTROL
+    assert cmd.payload is not None
+    assert cmd.payload.yaw == 25
+    # 45/90*1000 = 500
+    assert cmd.payload.duration_ms == 500
+
+
+def test_duration_clamps(interp: NavInterpreter) -> None:
+    # Large distance → clamp to 800
+    decision_large = make_decision(
+        "move_forward",
+        params={"distance_cm": 500, "speed_cm_s": 10},
+        confidence=0.8,
+    )
+    cmd_large = interp._map_action(decision_large)
+    assert cmd_large.payload is not None
+    assert cmd_large.payload.duration_ms == 800
+
+    # Tiny distance → clamp to 100
+    decision_tiny = make_decision(
+        "move_forward",
+        params={"distance_cm": 1, "speed_cm_s": 100},
+        confidence=0.8,
+    )
+    cmd_tiny = interp._map_action(decision_tiny)
+    assert cmd_tiny.payload is not None
+    assert cmd_tiny.payload.duration_ms == 100
+
+
+def test_ttl_exceeds_duration(interp: NavInterpreter) -> None:
+    for action in ALL_ACTIONS:
+        decision = make_decision(action, confidence=0.8)
+        cmd = interp._map_action(decision)
+        if cmd.ttl_ms is not None and cmd.payload is not None:
+            assert cmd.ttl_ms >= cmd.payload.duration_ms + 100, (
+                f"ttl_ms={cmd.ttl_ms} not >= duration_ms={cmd.payload.duration_ms}+100 for action={action}"
+            )
+
+
+def test_low_confidence_hovers(interp: NavInterpreter) -> None:
+    decision = make_decision("move_forward", confidence=0.3)
+    cmd = interp._map_action(decision)
+
+    assert cmd.type == CommandType.HOVER
+    assert cmd.payload is None
+    assert cmd.issued_by == "nav_interpreter"


### PR DESCRIPTION
## Summary
- ZMQ subscriber on port 5558 consuming NavigationOutput JSON from Rafa's pipeline
- Maps all 10 valid semantic actions (move_forward, rotate_left, hover, land, etc.) to DroneCommand payloads per CONSTITUTION contract
- Confidence < 0.5 overrides to hover (CONSTITUTION compliance)
- POSTs DroneCommand to safety harness at /commands
- Introduces structured logging for nav decisions

## Acceptance Criteria (Issue #16)
- [x] Subscribes to ZMQ 5558 (JSON NavigationOutput per CONSTITUTION)
- [x] Maps all 10 valid actions to rc_control payloads
- [x] Confidence < 0.5 → hover fallback
- [x] Posts DroneCommand to harness /commands endpoint
- [x] Logs every decision received + command sent
- [x] 6 unit tests passing, 0 regressions

## Test plan
- `pytest tests/test_nav_interpreter.py -v` — 6/6 passing
- Full suite: 25/26 passing (1 pre-existing failure unrelated)