### PR TITLE
feat: add Palantir ontology prep docs and sample data

### DIFF
--- a/demo/sample_decisions.csv
+++ b/demo/sample_decisions.csv
@@ -1,0 +1,16 @@
+decisionId,scanId,timestamp,fromState,toState,action,confidence,reasoning,batteryPercent
+d1a2b3c4,scan-demo-001,2026-05-02T14:00:00Z,exploring,exploring,move_forward,0.88,Open corridor ahead no obstacles detected,95
+d2b3c4d5,scan-demo-001,2026-05-02T14:00:04Z,exploring,exploring,rotate_right,0.82,Unmapped sector to starboard initiating sweep,92
+d3c4d5e6,scan-demo-001,2026-05-02T14:00:08Z,exploring,exploring,move_forward,0.85,Heading confirmed clear proceeding,90
+d4d5e6f7,scan-demo-001,2026-05-02T14:00:12Z,exploring,investigating_poi,hover,0.91,Suspicious object detected high confidence stopping to analyze,88
+d5e6f7a8,scan-demo-001,2026-05-02T14:00:17Z,investigating_poi,investigating_poi,hover,0.78,Maintaining position for secondary VLM confirmation,85
+d6f7a8b9,scan-demo-001,2026-05-02T14:00:21Z,investigating_poi,exploring,move_forward,0.84,POI logged resuming grid sweep,83
+d7a8b9c0,scan-demo-001,2026-05-02T14:00:25Z,exploring,exploring,move_right,0.80,Adjusting lateral position to cover unmapped corridor,80
+d8b9c0d1,scan-demo-001,2026-05-02T14:00:30Z,exploring,obstacle_avoidance,rotate_left,0.76,Wall detected at forward range initiating avoidance,76
+d9c0d1e2,scan-demo-001,2026-05-02T14:00:34Z,obstacle_avoidance,obstacle_avoidance,move_up,0.70,Obstacle at current altitude ascending to clear,72
+d0d1e2f3,scan-demo-001,2026-05-02T14:00:38Z,obstacle_avoidance,exploring,move_forward,0.83,Obstacle cleared resuming exploration,68
+d1e2f3a4,scan-demo-001,2026-05-02T14:00:43Z,exploring,exploring,move_forward,0.87,Final room sector coverage in progress,60
+d2f3a4b5,scan-demo-001,2026-05-02T14:00:48Z,exploring,returning,rotate_left,0.90,Coverage complete initiating return to origin,45
+d3a4b5c6,scan-demo-001,2026-05-02T14:00:52Z,returning,returning,move_back,0.92,Retracing outbound path low battery protocol active,35
+d4b5c6d7,scan-demo-001,2026-05-02T14:00:56Z,returning,low_battery,hover,0.95,Battery critical threshold reached holding for emergency landing,22
+d5c6d7e8,scan-demo-001,2026-05-02T14:01:00Z,low_battery,low_battery,land,0.97,Battery at 20 percent executing controlled landing,20

--- a/demo/sample_pois.csv
+++ b/demo/sample_pois.csv
@@ -1,0 +1,17 @@
+poiId,scanId,category,label,confidence,posX,posY,posZ,floor,threatLevel,createdAt
+T1-01-001,scan-demo-001,T1-01,Main Entry Door,0.92,1.1,1.5,0.0,0,CLEAR,2026-05-02T14:00:00Z
+T1-01-002,scan-demo-001,T1-01,Emergency Exit East,0.88,11.8,2.0,0.0,0,CLEAR,2026-05-02T14:00:05Z
+T1-02-001,scan-demo-001,T1-02,Hallway Fatal Funnel,0.85,4.2,1.5,0.0,0,WARM,2026-05-02T14:00:10Z
+T1-02-002,scan-demo-001,T1-02,Stairwell Fatal Funnel,0.79,5.9,1.8,0.0,0,CAUTION,2026-05-02T14:00:15Z
+T1-03-001,scan-demo-001,T1-03,Stairwell Ascent,0.91,6.1,2.0,1.5,1,CAUTION,2026-05-02T14:00:20Z
+T1-03-002,scan-demo-001,T1-03,Stairwell Landing,0.87,6.0,2.1,3.0,1,CLEAR,2026-05-02T14:00:25Z
+T2-02-001,scan-demo-001,T2-02,Overturned Furniture,0.73,9.4,2.5,0.0,0,WARM,2026-05-02T14:00:30Z
+T2-02-002,scan-demo-001,T2-02,Suspicious Package,0.68,3.2,1.2,0.0,0,HOT,2026-05-02T14:00:35Z
+T2-03-001,scan-demo-001,T2-03,Corridor Chokepoint,0.82,5.0,1.5,0.0,0,CAUTION,2026-05-02T14:00:40Z
+T2-03-002,scan-demo-001,T2-03,Doorway Bottleneck,0.77,7.9,1.5,0.0,0,CAUTION,2026-05-02T14:00:45Z
+T3-01-001,scan-demo-001,T3-01,Electrical Panel Room 1,0.89,2.8,2.8,0.0,0,INFO,2026-05-02T14:00:50Z
+T3-01-002,scan-demo-001,T3-01,HVAC Access Panel,0.71,10.3,0.8,0.0,0,INFO,2026-05-02T14:00:55Z
+T4-01-001,scan-demo-001,T4-01,Ceiling Collapse Zone,0.65,8.1,1.0,2.8,0,WARM,2026-05-02T14:01:00Z
+ROOM-001,scan-demo-001,ROOM,Office Room A,0.94,2.5,2.0,0.0,0,CLEAR,2026-05-02T14:01:05Z
+ROOM-002,scan-demo-001,ROOM,Storage Room B,0.90,10.0,2.0,0.0,0,CLEAR,2026-05-02T14:01:10Z
+ROOM-003,scan-demo-001,ROOM,Corridor Segment C,0.93,6.0,1.5,0.0,0,CLEAR,2026-05-02T14:01:15Z

--- a/docs/palantir-ontology-setup.md
+++ b/docs/palantir-ontology-setup.md
@@ -1,0 +1,200 @@
+# Palantir Ontology Setup — BreachEye
+
+Hackathon-pace guide. Copy-paste actionable. Time budget: 3h total, cut at H+8 if not live.
+
+---
+
+## 1. Prerequisites
+
+**Environment variables — set before anything else:**
+
+```bash
+export FOUNDRY_HOST="https://<your-foundry-hostname>"
+export FOUNDRY_TOKEN="<your-bearer-token>"
+```
+
+**Python SDK:**
+
+```bash
+pip install foundry-platform-sdk
+# or if using uv:
+uv pip install foundry-platform-sdk
+```
+
+**Verify connectivity:**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $FOUNDRY_TOKEN" \
+  "$FOUNDRY_HOST/api/v2/ontologies"
+# Expect 200
+```
+
+---
+
+## 2. Create TacticalPoi Object Type
+
+In **Ontology Manager UI** (`$FOUNDRY_HOST/ontology-manager`):
+
+1. Click **New Object Type** → name: `TacticalPoi`
+2. Add properties in order:
+
+| Property | Foundry Type | Notes |
+|----------|-------------|-------|
+| `poiId` | String | Set as **Primary Key** |
+| `scanId` | String | |
+| `category` | String | T1-01 through ROOM |
+| `label` | String | Human-readable description |
+| `confidence` | Double | Range 0.0–1.0 |
+| `posX` | Double | X coord, meters, local frame |
+| `posY` | Double | Y coord, meters, local frame |
+| `posZ` | Double | Z coord, meters, local frame |
+| `floor` | Integer | 0 = ground floor |
+| `threatLevel` | String | HOT/WARM/CAUTION/CLEAR/INFO |
+| `createdAt` | Timestamp | ISO 8601 |
+
+3. Set `poiId` as **Primary Key** (click the key icon on that property row).
+4. **Note:** Foundry has no native 3D point type — use three separate Doubles (`posX`, `posY`, `posZ`).
+5. Click **Save** → **Publish**.
+
+---
+
+## 3. Create FlightDecision Object Type
+
+1. Click **New Object Type** → name: `FlightDecision`
+2. Add properties:
+
+| Property | Foundry Type | Notes |
+|----------|-------------|-------|
+| `decisionId` | String | Set as **Primary Key** |
+| `scanId` | String | FK — links to parent scan |
+| `timestamp` | Timestamp | When decision was made |
+| `fromState` | String | State machine prior state |
+| `toState` | String | State machine next state |
+| `action` | String | move_forward, rotate_left, etc. |
+| `confidence` | Double | VLM confidence 0.0–1.0 |
+| `reasoning` | String | VLM explanation string |
+| `batteryPercent` | Integer | Tello battery at decision time |
+
+3. Set `decisionId` as **Primary Key**.
+4. Click **Save** → **Publish**.
+
+---
+
+## 4. Create Action Types
+
+### Action: `create-tactical-poi`
+
+1. In Ontology Manager → **Actions** → **New Action Type**
+2. Name: `create-tactical-poi`
+3. Add parameters (one per property, matching names exactly):
+
+| Parameter | Type | Maps to |
+|-----------|------|---------|
+| `poiId` | String | TacticalPoi.poiId (PK) |
+| `scanId` | String | TacticalPoi.scanId |
+| `category` | String | TacticalPoi.category |
+| `label` | String | TacticalPoi.label |
+| `confidence` | Double | TacticalPoi.confidence |
+| `posX` | Double | TacticalPoi.posX |
+| `posY` | Double | TacticalPoi.posY |
+| `posZ` | Double | TacticalPoi.posZ |
+| `floor` | Integer | TacticalPoi.floor |
+| `threatLevel` | String | TacticalPoi.threatLevel |
+| `createdAt` | Timestamp | TacticalPoi.createdAt |
+
+4. Logic: **Create Object** → select `TacticalPoi` → map each parameter to its property.
+5. Click **Save** → **Publish**.
+
+### Action: `log-flight-decision`
+
+1. **New Action Type** → name: `log-flight-decision`
+2. Parameters:
+
+| Parameter | Type | Maps to |
+|-----------|------|---------|
+| `decisionId` | String | FlightDecision.decisionId (PK) |
+| `scanId` | String | FlightDecision.scanId |
+| `timestamp` | Timestamp | FlightDecision.timestamp |
+| `fromState` | String | FlightDecision.fromState |
+| `toState` | String | FlightDecision.toState |
+| `action` | String | FlightDecision.action |
+| `confidence` | Double | FlightDecision.confidence |
+| `reasoning` | String | FlightDecision.reasoning |
+| `batteryPercent` | Integer | FlightDecision.batteryPercent |
+
+3. Logic: **Create Object** → select `FlightDecision` → map each parameter.
+4. Click **Save** → **Publish**.
+
+---
+
+## 5. Upload Sample Data
+
+1. In Foundry **Data Connection** or **Datasets** → **Upload File**
+2. Upload `demo/sample_pois.csv` → name dataset `breacheye_sample_pois`
+3. Upload `demo/sample_decisions.csv` → name dataset `breacheye_sample_decisions`
+4. For each dataset → **Sync to Ontology**:
+   - `breacheye_sample_pois` → object type `TacticalPoi`, primary key column `poiId`
+   - `breacheye_sample_decisions` → object type `FlightDecision`, primary key column `decisionId`
+5. Trigger sync → verify row counts match CSV.
+
+---
+
+## 6. Verify
+
+**Query TacticalPoi objects back:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $FOUNDRY_TOKEN" \
+  "$FOUNDRY_HOST/api/v2/ontologies/palantir/objects/TacticalPoi?pageSize=5" \
+  | python3 -m json.tool
+```
+
+**Query FlightDecision objects:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $FOUNDRY_TOKEN" \
+  "$FOUNDRY_HOST/api/v2/ontologies/palantir/objects/FlightDecision?pageSize=5" \
+  | python3 -m json.tool
+```
+
+**Test single create-tactical-poi action:**
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $FOUNDRY_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$FOUNDRY_HOST/api/v2/ontologies/palantir/actions/create-tactical-poi/apply" \
+  -d '{
+    "parameters": {
+      "poiId": "T1-01-999",
+      "scanId": "scan-verify-001",
+      "category": "T1-01",
+      "label": "Test Entry Point",
+      "confidence": 0.9,
+      "posX": 1.0,
+      "posY": 1.0,
+      "posZ": 0.0,
+      "floor": 0,
+      "threatLevel": "INFO",
+      "createdAt": "2026-05-02T14:00:00Z"
+    }
+  }'
+# Expect {"edits": {...}}
+```
+
+---
+
+## 7. Workshop Dashboard
+
+Build in **Workshop** (`$FOUNDRY_HOST/workspace/module-editor`):
+
+- [ ] **Map widget** — 2D floor plan overlay, plot TacticalPoi by posX/posY, color by `category` or `threatLevel`
+- [ ] **Object table** — TacticalPoi table, columns: poiId, label, category, threatLevel, confidence, floor
+- [ ] **Metric cards** — POI count by threatLevel (HOT, WARM, CAUTION, CLEAR), battery gauge from latest FlightDecision
+- [ ] **AIP chatbot** — Attach AIP Agent, give it access to TacticalPoi and FlightDecision object sets, prompt: "Tactical analyst for indoor drone ops"
+- [ ] **Filter** — scanId dropdown to isolate active mission
+
+Time budget: 45min for map + table, 30min for chatbot. Cut chatbot if behind.


### PR DESCRIPTION
## Summary
- `docs/palantir-ontology-setup.md` — step-by-step Ontology Manager runbook: TacticalPoi + FlightDecision object types, action types, CSV upload, verification, Workshop checklist
- `demo/sample_pois.csv` — 16 realistic POIs across all 8 categories, simulating a building layout (2 rooms, corridor, stairwell)
- `demo/sample_decisions.csv` — 15 flight decisions tracing a coherent arc: exploring → investigating → obstacle avoidance → returning → low_battery → land

P2 stretch goal. Pre-written for on-site deployment — copy-paste actionable.

## Test plan
- [ ] Verify CSV headers match `palantir.md` schema exactly
- [ ] Verify all 8 POI categories present in sample_pois.csv
- [ ] Walk through setup doc steps against Foundry UI on-site