### PR TITLE
feat: add detection bbox overlay with ZMQ-to-WS bridge (#23)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -337,6 +337,23 @@
   margin: 4px 14px;
 }
 
+/* ── Video overlay container ─────────────────────────────── */
+
+.video-overlay-container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.detection-overlay__canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
 /* ── Responsive: 1920×1080 primary target ───────────────── */
 
 @media (min-width: 1600px) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,13 @@
+import { useRef } from 'react'
 import VideoPanel from './components/VideoPanel'
+import DetectionOverlay from './components/DetectionOverlay'
 import PlaceholderCard from './components/PlaceholderCard'
 import TelemetryHUD from './components/TelemetryHUD'
 import './App.css'
 
 export default function App() {
+  const videoFrameRef = useRef(null)
+
   return (
     <div className="app">
       <header className="app__header">
@@ -18,12 +22,14 @@ export default function App() {
 
       <main className="app__body">
         <section className="app__video">
-          <VideoPanel />
+          <div className="video-overlay-container">
+            <VideoPanel frameRef={videoFrameRef} />
+            <DetectionOverlay containerRef={videoFrameRef} />
+          </div>
         </section>
 
         <aside className="app__sidebar">
           <TelemetryHUD />
-          <PlaceholderCard label="DETECTION OVERLAY" ticket="23" />
           <PlaceholderCard label="TACTICAL MAP" ticket="25" />
         </aside>
       </main>

--- a/frontend/src/components/DetectionOverlay.jsx
+++ b/frontend/src/components/DetectionOverlay.jsx
@@ -1,0 +1,240 @@
+import { useEffect, useRef, useCallback } from 'react'
+
+// NOTE: This component creates its own WebSocket connection to /events.
+// When TelemetryHUD (PR #33) is merged, consolidate both into a shared
+// useWebSocket hook to avoid duplicate connections.
+const WS_URL = 'ws://localhost:8000/events'
+
+// Source resolution for coordinate scaling
+const SRC_W = 960
+const SRC_H = 720
+
+// POI category colors per CONSTITUTION
+const CATEGORY_COLORS = {
+  'T1-01': '#60a5fa',
+  'T1-02': '#f87171',
+  'T1-03': '#818cf8',
+  'T2-02': '#f87171',
+  'T2-03': '#fbbf24',
+  'T3-01': '#a78bfa',
+  'T4-01': '#fb923c',
+  'ROOM':  '#2dd4bf',
+}
+
+const THREAT_COLORS = {
+  HOT:     '#ef4444',
+  WARM:    '#f97316',
+  CAUTION: '#eab308',
+  CLEAR:   '#22c55e',
+}
+
+const DEFAULT_COLOR = '#94a3b8'
+
+const LIFETIME_MS = 2000
+const FADE_START_MS = 1500
+
+function hexToRgb(hex) {
+  const n = parseInt(hex.slice(1), 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+// containerRef points to video-panel__frame — the element that renders the
+// actual video. The canvas is a sibling of VideoPanel inside
+// .video-overlay-container, so we must compute the frame's position relative
+// to its offset parent to place the canvas correctly.
+export default function DetectionOverlay({ containerRef }) {
+  const canvasRef = useRef(null)
+  const detectionsRef = useRef([])
+  const rafRef = useRef(null)
+  const wsRef = useRef(null)
+
+  const drawFrame = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    const now = Date.now()
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+    detectionsRef.current = detectionsRef.current.filter(
+      (e) => now - e.arrivedAt < LIFETIME_MS
+    )
+
+    if (detectionsRef.current.length === 0) {
+      rafRef.current = requestAnimationFrame(drawFrame)
+      return
+    }
+
+    const scaleX = canvas.width / SRC_W
+    const scaleY = canvas.height / SRC_H
+
+    for (const entry of detectionsRef.current) {
+      const { detection, arrivedAt } = entry
+      const age = now - arrivedAt
+      let opacity = 1
+      if (age >= FADE_START_MS) {
+        opacity = 1 - (age - FADE_START_MS) / (LIFETIME_MS - FADE_START_MS)
+      }
+      opacity = Math.max(0, Math.min(1, opacity))
+
+      const { category, label, confidence, bbox_2d, threat_level } = detection
+      const color = CATEGORY_COLORS[category] ?? DEFAULT_COLOR
+      const [r, g, b] = hexToRgb(color)
+
+      const x = bbox_2d.x1 * scaleX
+      const y = bbox_2d.y1 * scaleY
+      const w = (bbox_2d.x2 - bbox_2d.x1) * scaleX
+      const h = (bbox_2d.y2 - bbox_2d.y1) * scaleY
+
+      ctx.save()
+      ctx.globalAlpha = opacity
+
+      // Bbox rectangle
+      ctx.strokeStyle = color
+      ctx.lineWidth = 2
+      ctx.strokeRect(x, y, w, h)
+
+      // Label: "{category_code} {label} {confidence}%"
+      const pct = Math.round(confidence * 100)
+      const labelText = `${category} ${label} ${pct}%`
+      ctx.font = '11px monospace'
+      ctx.textBaseline = 'bottom'
+      const textMetrics = ctx.measureText(labelText)
+      const textW = textMetrics.width + 8
+      const textH = 16
+      const textX = x
+      const textY = y - 2
+
+      // Semi-transparent label background
+      ctx.fillStyle = `rgba(${r}, ${g}, ${b}, 0.2)`
+      ctx.fillRect(textX, textY - textH, textW, textH)
+
+      ctx.strokeStyle = `rgba(${r}, ${g}, ${b}, 0.6)`
+      ctx.lineWidth = 1
+      ctx.strokeRect(textX, textY - textH, textW, textH)
+
+      ctx.fillStyle = color
+      ctx.fillText(labelText, textX + 4, textY - 2)
+
+      // Threat badge — top-right corner of bbox
+      const threatColor = THREAT_COLORS[threat_level] ?? DEFAULT_COLOR
+      const [tr, tg, tb] = hexToRgb(threatColor)
+      const badgeText = threat_level ?? 'INFO'
+      const badgeW = ctx.measureText(badgeText).width + 8
+      const badgeH = 14
+      const badgeX = x + w - badgeW
+      const badgeY = y
+
+      ctx.fillStyle = `rgba(${tr}, ${tg}, ${tb}, 0.25)`
+      ctx.fillRect(badgeX, badgeY, badgeW, badgeH)
+
+      ctx.strokeStyle = `rgba(${tr}, ${tg}, ${tb}, 0.7)`
+      ctx.lineWidth = 1
+      ctx.strokeRect(badgeX, badgeY, badgeW, badgeH)
+
+      ctx.font = '9px monospace'
+      ctx.textBaseline = 'top'
+      ctx.fillStyle = threatColor
+      ctx.fillText(badgeText, badgeX + 4, badgeY + 3)
+
+      ctx.restore()
+    }
+
+    rafRef.current = requestAnimationFrame(drawFrame)
+  }, [])
+
+  // Sync canvas size and position to the video frame element
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const frameEl = containerRef?.current
+    if (!canvas || !frameEl) return
+
+    function syncToFrame() {
+      const frameRect = frameEl.getBoundingClientRect()
+      const parentRect = canvas.offsetParent?.getBoundingClientRect() ?? frameRect
+
+      canvas.style.left = `${frameRect.left - parentRect.left}px`
+      canvas.style.top = `${frameRect.top - parentRect.top}px`
+      canvas.width = Math.round(frameRect.width)
+      canvas.height = Math.round(frameRect.height)
+    }
+
+    syncToFrame()
+
+    const ro = new ResizeObserver(syncToFrame)
+    ro.observe(frameEl)
+
+    return () => ro.disconnect()
+  }, [containerRef])
+
+  // WebSocket subscription
+  useEffect(() => {
+    let ws
+    let reconnectTimer
+
+    function connect() {
+      ws = new WebSocket(WS_URL)
+      wsRef.current = ws
+
+      ws.onmessage = (event) => {
+        try {
+          const envelope = JSON.parse(event.data)
+          if (envelope.topic !== 'drone.detections') return
+          const msg = envelope.message
+          if (!Array.isArray(msg?.detections)) return
+
+          const now = Date.now()
+          const incoming = msg.detections.map((detection) => ({
+            detection,
+            arrivedAt: now,
+          }))
+
+          // Refresh timestamps for existing IDs; append new ones
+          detectionsRef.current = [
+            ...detectionsRef.current.filter(
+              (e) => !incoming.some((n) => n.detection.id === e.detection.id)
+            ),
+            ...incoming,
+          ]
+        } catch {
+          // Malformed frame — skip
+        }
+      }
+
+      ws.onclose = () => {
+        reconnectTimer = setTimeout(connect, 2000)
+      }
+
+      ws.onerror = () => {
+        ws.close()
+      }
+    }
+
+    connect()
+
+    return () => {
+      clearTimeout(reconnectTimer)
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.close()
+      }
+    }
+  }, [])
+
+  // Animation loop
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(drawFrame)
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [drawFrame])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="detection-overlay__canvas"
+      aria-hidden="true"
+    />
+  )
+}

--- a/frontend/src/components/DetectionOverlay.jsx
+++ b/frontend/src/components/DetectionOverlay.jsx
@@ -26,6 +26,7 @@ const THREAT_COLORS = {
   WARM:    '#f97316',
   CAUTION: '#eab308',
   CLEAR:   '#22c55e',
+  INFO:    '#94a3b8',
 }
 
 const DEFAULT_COLOR = '#94a3b8'
@@ -44,15 +45,19 @@ function hexToRgb(hex) {
 // to its offset parent to place the canvas correctly.
 export default function DetectionOverlay({ containerRef }) {
   const canvasRef = useRef(null)
+  const ctxRef = useRef(null)
   const detectionsRef = useRef([])
   const rafRef = useRef(null)
   const wsRef = useRef(null)
+  const backoffRef = useRef(1000)
+  const reconnectRef = useRef(null)
 
   const drawFrame = useCallback(() => {
     const canvas = canvasRef.current
     if (!canvas) return
 
-    const ctx = canvas.getContext('2d')
+    const ctx = ctxRef.current
+    if (!ctx) return
     const now = Date.now()
 
     ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -150,6 +155,8 @@ export default function DetectionOverlay({ containerRef }) {
     const frameEl = containerRef?.current
     if (!canvas || !frameEl) return
 
+    ctxRef.current = canvas.getContext('2d')
+
     function syncToFrame() {
       const frameRect = frameEl.getBoundingClientRect()
       const parentRect = canvas.offsetParent?.getBoundingClientRect() ?? frameRect
@@ -171,11 +178,14 @@ export default function DetectionOverlay({ containerRef }) {
   // WebSocket subscription
   useEffect(() => {
     let ws
-    let reconnectTimer
 
     function connect() {
       ws = new WebSocket(WS_URL)
       wsRef.current = ws
+
+      ws.onopen = () => {
+        backoffRef.current = 1000
+      }
 
       ws.onmessage = (event) => {
         try {
@@ -203,18 +213,17 @@ export default function DetectionOverlay({ containerRef }) {
       }
 
       ws.onclose = () => {
-        reconnectTimer = setTimeout(connect, 2000)
+        reconnectRef.current = setTimeout(connect, backoffRef.current)
+        backoffRef.current = Math.min(backoffRef.current * 2, 30000)
       }
 
-      ws.onerror = () => {
-        ws.close()
-      }
+      ws.onerror = () => {}
     }
 
     connect()
 
     return () => {
-      clearTimeout(reconnectTimer)
+      clearTimeout(reconnectRef.current)
       if (wsRef.current) {
         wsRef.current.onclose = null
         wsRef.current.close()

--- a/frontend/src/components/VideoPanel.jsx
+++ b/frontend/src/components/VideoPanel.jsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 
 const MJPEG_URL = '/api/video.mjpeg'
 
-export default function VideoPanel() {
+export default function VideoPanel({ frameRef }) {
   const [hasSignal, setHasSignal] = useState(true)
   const retryRef = useRef(null)
 
@@ -45,7 +45,7 @@ export default function VideoPanel() {
         </div>
       </div>
 
-      <div className="video-panel__frame">
+      <div className="video-panel__frame" ref={frameRef}>
         {hasSignal ? (
           <img
             src={MJPEG_URL}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi>=0.115",
     "httpx>=0.27",
     "pydantic>=2.7",
+    "pyzmq>=26.0",
     "uvicorn[standard]>=0.30",
 ]
 

--- a/src/breacheye/service.py
+++ b/src/breacheye/service.py
@@ -65,19 +65,25 @@ class HarnessRuntime:
 
     async def _zmq_reader(self) -> None:
         assert self._zmq_socket is not None
-        try:
-            while True:
-                raw = await self._zmq_socket.recv()
-                try:
-                    payload = json.loads(raw)
-                except json.JSONDecodeError as exc:
-                    log.debug("ZMQ: bad JSON from detections channel: %s", exc)
-                    continue
-                await self.bus.publish("drone.detections", payload)
-        except asyncio.CancelledError:
-            pass
-        except Exception as exc:
-            log.warning("ZMQ reader exited unexpectedly: %s", exc)
+        backoff = 1.0
+        max_backoff = 30.0
+        while True:
+            try:
+                while True:
+                    raw = await self._zmq_socket.recv()
+                    try:
+                        payload = json.loads(raw)
+                    except json.JSONDecodeError as exc:
+                        log.debug("ZMQ: bad JSON from detections channel: %s", exc)
+                        continue
+                    await self.bus.publish("drone.detections", payload)
+                    backoff = 1.0
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                log.warning("ZMQ reader failed: %s — retrying in %.0fs", exc, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, max_backoff)
 
     def _cleanup_zmq(self) -> None:
         if self._zmq_socket is not None:

--- a/src/breacheye/service.py
+++ b/src/breacheye/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
@@ -16,6 +17,10 @@ from breacheye.models import CommandResult, CommandStatus, DroneCommand
 from breacheye.safety import SafetyController
 from breacheye.video import FrameStore, TelloVideoPump
 
+log = logging.getLogger(__name__)
+
+_ZMQ_DETECTIONS_PORT = 5556
+
 
 class HarnessRuntime:
     """Owns the process-local drone resources exposed by the HTTP/WebSocket API."""
@@ -27,6 +32,9 @@ class HarnessRuntime:
         self.adapter = make_adapter(mode)
         self.safety = SafetyController(self.adapter, self.bus)
         self.video_pump: TelloVideoPump | None = None
+        self._zmq_task: asyncio.Task | None = None
+        self._zmq_socket = None
+        self._zmq_ctx = None
 
     async def start(self) -> None:
         await self.adapter.connect()
@@ -34,8 +42,66 @@ class HarnessRuntime:
         if self.mode == "tello":
             self.video_pump = TelloVideoPump(self.adapter, self.frame_store, self.bus)
             await self.video_pump.start()
+        self._start_zmq_bridge()
+
+    def _start_zmq_bridge(self) -> None:
+        try:
+            import zmq
+            import zmq.asyncio as azmq
+
+            self._zmq_ctx = azmq.Context()
+            self._zmq_socket = self._zmq_ctx.socket(zmq.SUB)
+            self._zmq_socket.connect(f"tcp://localhost:{_ZMQ_DETECTIONS_PORT}")
+            self._zmq_socket.setsockopt(zmq.SUBSCRIBE, b"")
+            self._zmq_task = asyncio.create_task(
+                self._zmq_reader(), name="zmq-detections-bridge"
+            )
+            log.info("ZMQ detections bridge started on port %d", _ZMQ_DETECTIONS_PORT)
+        except ImportError:
+            log.warning("pyzmq not installed — detection overlay bridge disabled")
+        except Exception as exc:
+            log.warning("ZMQ bridge init failed (%s) — detection overlay disabled", exc)
+            self._cleanup_zmq()
+
+    async def _zmq_reader(self) -> None:
+        assert self._zmq_socket is not None
+        try:
+            while True:
+                raw = await self._zmq_socket.recv()
+                try:
+                    payload = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    log.debug("ZMQ: bad JSON from detections channel: %s", exc)
+                    continue
+                await self.bus.publish("drone.detections", payload)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            log.warning("ZMQ reader exited unexpectedly: %s", exc)
+
+    def _cleanup_zmq(self) -> None:
+        if self._zmq_socket is not None:
+            try:
+                self._zmq_socket.close()
+            except Exception:
+                pass
+            self._zmq_socket = None
+        if self._zmq_ctx is not None:
+            try:
+                self._zmq_ctx.term()
+            except Exception:
+                pass
+            self._zmq_ctx = None
 
     async def stop(self) -> None:
+        if self._zmq_task is not None:
+            self._zmq_task.cancel()
+            try:
+                await self._zmq_task
+            except asyncio.CancelledError:
+                pass
+            self._zmq_task = None
+        self._cleanup_zmq()
         if self.video_pump is not None:
             await self.video_pump.stop()
         await self.safety.stop()
@@ -127,7 +193,7 @@ def create_app(mode: str = "sim") -> FastAPI:
     @app.websocket("/events")
     async def events(websocket: WebSocket):
         await websocket.accept()
-        topics = ["drone.telemetry", "drone.command_results", "drone.frames.llm"]
+        topics = ["drone.telemetry", "drone.command_results", "drone.frames.llm", "drone.detections"]
         queues = {topic: await runtime.bus.subscribe(topic) for topic in topics}
         tasks: set[asyncio.Task] = set()
         try:


### PR DESCRIPTION
## Summary

Canvas overlay rendering detection bounding boxes on the MJPEG feed. ZMQ-to-WebSocket bridge in the harness subscribes to port 5556 and publishes as `drone.detections` topic. Color-coded by POI category per CONSTITUTION. 2-second fade-out for stale detections. ResizeObserver keeps canvas aligned. requestAnimationFrame for smooth rendering.

Closes #23

Depends on: #31 (merged)

## Test Plan

- Run `breacheye serve --mode sim`
- Run `python demo/mock_detections.py`
- Run `cd frontend && npm run dev`
- Verify colored bboxes render over video feed with labels and threat badges

## Review

Tali reviewed — 10/10 checks pass:
- Canvas alignment
- Scaling
- Fade-out
- Colors (POI category per CONSTITUTION)
- Degradation
- WS reconnect
- RAF cleanup
- ZMQ graceful import
- Ref forwarding
- Memory management