### PR TITLE
feat: add telemetry HUD with WebSocket + fallback polling (#22)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -250,6 +250,93 @@
   letter-spacing: 0.06em;
 }
 
+/* ── Telemetry HUD ───────────────────────────────────────── */
+
+.telemetry-hud {
+  flex: 1;
+  min-height: 120px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.telemetry-hud__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+}
+
+.telemetry-hud__title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: #60a5fa;
+}
+
+.telemetry-hud__ws {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+}
+
+.telemetry-hud__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 8px 0;
+}
+
+.telemetry-hud__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 14px;
+}
+
+.telemetry-hud__label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: #60a5fa;
+  opacity: 0.7;
+}
+
+.telemetry-hud__value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.telemetry-hud__status-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.telemetry-hud__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.telemetry-hud__divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: 4px 14px;
+}
+
 /* ── Responsive: 1920×1080 primary target ───────────────── */
 
 @media (min-width: 1600px) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import VideoPanel from './components/VideoPanel'
 import PlaceholderCard from './components/PlaceholderCard'
+import TelemetryHUD from './components/TelemetryHUD'
 import './App.css'
 
 export default function App() {
@@ -21,7 +22,7 @@ export default function App() {
         </section>
 
         <aside className="app__sidebar">
-          <PlaceholderCard label="TELEMETRY HUD" ticket="22" />
+          <TelemetryHUD />
           <PlaceholderCard label="DETECTION OVERLAY" ticket="23" />
           <PlaceholderCard label="TACTICAL MAP" ticket="25" />
         </aside>

--- a/frontend/src/components/TelemetryHUD.jsx
+++ b/frontend/src/components/TelemetryHUD.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react'
+
+const WS_URL = 'ws://localhost:8000/events'
+const HEALTH_URL = 'http://localhost:8000/health'
+const POLL_INTERVAL_MS = 2000
+const RECONNECT_DELAY_MS = 1000
+
+function batteryColor(battery) {
+  if (battery === null || battery === undefined) return '#6b7280'
+  if (battery > 50) return '#22c55e'
+  if (battery >= 20) return '#eab308'
+  return '#ef4444'
+}
+
+function formatFlightTime(seconds) {
+  if (seconds === null || seconds === undefined) return '--:--'
+  const m = Math.floor(seconds / 60).toString().padStart(2, '0')
+  const s = (seconds % 60).toString().padStart(2, '0')
+  return `${m}:${s}`
+}
+
+export default function TelemetryHUD() {
+  const [telemetry, setTelemetry] = useState(null)
+  const [wsConnected, setWsConnected] = useState(false)
+  const wsRef = useRef(null)
+  const pollRef = useRef(null)
+  const reconnectRef = useRef(null)
+
+  function startPolling() {
+    if (pollRef.current) return
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(HEALTH_URL)
+        if (res.ok) {
+          const data = await res.json()
+          if (data.telemetry) setTelemetry(data.telemetry)
+        }
+      } catch {
+        // server not yet up, keep trying
+      }
+    }, POLL_INTERVAL_MS)
+  }
+
+  function stopPolling() {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }
+
+  function connect() {
+    const ws = new WebSocket(WS_URL)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setWsConnected(true)
+      stopPolling()
+    }
+
+    ws.onmessage = (evt) => {
+      try {
+        const msg = JSON.parse(evt.data)
+        if (msg.topic === 'drone.telemetry' && msg.message) {
+          setTelemetry(msg.message)
+        }
+      } catch {
+        // malformed message, ignore
+      }
+    }
+
+    ws.onclose = () => {
+      setWsConnected(false)
+      startPolling()
+      reconnectRef.current = setTimeout(connect, RECONNECT_DELAY_MS)
+    }
+
+    ws.onerror = () => {
+      ws.close()
+    }
+  }
+
+  useEffect(() => {
+    connect()
+    return () => {
+      clearTimeout(reconnectRef.current)
+      stopPolling()
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.close()
+      }
+    }
+  }, [])
+
+  const bat = telemetry?.battery ?? null
+  const alt = telemetry?.height_cm ?? null
+  const ft = telemetry?.flight_time_s ?? null
+  const connected = telemetry?.connected ?? false
+  const flying = telemetry?.flying ?? false
+
+  return (
+    <div className="telemetry-hud">
+      <div className="telemetry-hud__header">
+        <span className="telemetry-hud__title">TELEMETRY HUD</span>
+        <span className="telemetry-hud__ws" style={{ color: wsConnected ? '#22c55e' : '#6b7280' }}>
+          {wsConnected ? 'WS' : 'POLL'}
+        </span>
+      </div>
+
+      <div className="telemetry-hud__rows">
+        <div className="telemetry-hud__row">
+          <span className="telemetry-hud__label">BATTERY</span>
+          <span className="telemetry-hud__value" style={{ color: batteryColor(bat) }}>
+            {bat !== null ? `${bat}%` : '--'}
+          </span>
+        </div>
+
+        <div className="telemetry-hud__row">
+          <span className="telemetry-hud__label">ALTITUDE</span>
+          <span className="telemetry-hud__value">
+            {alt !== null ? `${alt} cm` : '--'}
+          </span>
+        </div>
+
+        <div className="telemetry-hud__row">
+          <span className="telemetry-hud__label">FLIGHT TIME</span>
+          <span className="telemetry-hud__value">{formatFlightTime(ft)}</span>
+        </div>
+
+        <div className="telemetry-hud__divider" />
+
+        <div className="telemetry-hud__row">
+          <span className="telemetry-hud__label">LINK</span>
+          <div className="telemetry-hud__status-group">
+            <span
+              className="telemetry-hud__dot"
+              style={{ background: connected ? '#22c55e' : '#ef4444' }}
+            />
+            <span
+              className="telemetry-hud__value"
+              style={{ color: connected ? '#22c55e' : '#ef4444' }}
+            >
+              {connected ? 'CONNECTED' : 'DISCONNECTED'}
+            </span>
+          </div>
+        </div>
+
+        <div className="telemetry-hud__row">
+          <span className="telemetry-hud__label">MODE</span>
+          <span
+            className="telemetry-hud__value"
+            style={{ color: flying ? '#60a5fa' : '#4b5563' }}
+          >
+            {flying ? 'AIRBORNE' : 'GROUNDED'}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- TelemetryHUD React component in sidebar. Real-time drone telemetry via WebSocket (`drone.telemetry` topic), auto-reconnect with 1s retry, HTTP `/health` fallback polling when WS disconnects.
- Battery color coding (green/yellow/red), flight time MM:SS, connection/flying status indicators.
- Clean cherry-pick of the single meaningful commit from #33 — scaffold and import cleanup commits were already present on main after #31 merged.

## Replaces

PR #33 (cherry-picked to resolve scaffold conflicts with main)

## Closes

Closes #22

## Test Plan

- [ ] Run `breacheye serve --mode sim` + `cd frontend && npm run dev`
- [ ] Verify telemetry updates in sidebar (battery %, altitude, flight time)
- [ ] Disconnect WebSocket — confirm fallback polling activates
- [ ] Reconnect — confirm WS resumes and polling stops
- [ ] Battery thresholds: verify green/yellow/red transitions at correct levels

## Review

Tali reviewed original PR — 7/7 checks pass: WS lifecycle, fallback polling, units, thresholds, memory leaks, null handling, message parsing.