### PR TITLE
feat: add exploration tracker with coverage and state mapping

### DIFF
--- a/src/breacheye/exploration_tracker.py
+++ b/src/breacheye/exploration_tracker.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from time import time
+
+from breacheye.bus import AsyncEventBus
+from breacheye.state_machine import FlightState, FlightStateMachine, InvalidTransition
+
+
+class ExplorationTracker:
+    """Tracks exploration progress from NavigationOutput decisions."""
+
+    def __init__(self, fsm: FlightStateMachine, bus: AsyncEventBus) -> None:
+        self._fsm = fsm
+        self._bus = bus
+        self._areas_visited: set[str] = set()
+        self._pois_found: int = 0
+        self._last_exploration_state: str = "exploring"
+        self._task: asyncio.Task | None = None
+        self._queue: asyncio.Queue | None = None
+
+    @property
+    def coverage_stats(self) -> dict:
+        """Expose stats for UI."""
+        return {
+            "areas_visited": len(self._areas_visited),
+            "pois_found": self._pois_found,
+            "last_exploration_state": self._last_exploration_state,
+        }
+
+    def record_poi(self) -> None:
+        """Increment POI counter (called externally when detection confirms a POI)."""
+        self._pois_found += 1
+
+    async def start(self) -> None:
+        """Subscribe to nav decisions on the bus and process them."""
+        self._queue = await self._bus.subscribe("drone.nav_decision")
+        self._task = asyncio.create_task(self._process_loop())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        if self._queue is not None:
+            await self._bus.unsubscribe("drone.nav_decision", self._queue)
+
+    async def _process_loop(self) -> None:
+        assert self._queue is not None
+        while True:
+            try:
+                nav_output = await self._queue.get()
+                await self._handle_nav(nav_output)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logging.getLogger(__name__).warning("exploration tracker error: %s", exc)
+
+    async def _handle_nav(self, nav_output: dict) -> None:
+        """Process a NavigationOutput dict from the bus."""
+        decision = nav_output.get("decision", {})
+        exploration_state = decision.get("exploration_state", "exploring")
+        self._last_exploration_state = exploration_state
+
+        reasoning = decision.get("reasoning", "")
+        if reasoning:
+            area_key = f"area-{hash(reasoning) % 10000}"
+            self._areas_visited.add(area_key)
+
+        if exploration_state == "coverage_complete":
+            if self._fsm.state in (FlightState.EXPLORING, FlightState.INVESTIGATING):
+                try:
+                    await self._fsm.transition(FlightState.RETURNING)
+                    await self._bus.publish("drone.exploration_event", {
+                        "event": "coverage_complete",
+                        "stats": self.coverage_stats,
+                        "timestamp": time(),
+                    })
+                except InvalidTransition:
+                    pass
+
+        elif exploration_state == "low_battery":
+            if self._fsm.state in (FlightState.EXPLORING, FlightState.INVESTIGATING):
+                try:
+                    await self._fsm.transition(FlightState.RETURNING)
+                    await self._bus.publish("drone.exploration_event", {
+                        "event": "low_battery_nav",
+                        "stats": self.coverage_stats,
+                        "timestamp": time(),
+                    })
+                except InvalidTransition:
+                    pass
+
+        elif exploration_state == "investigating_poi":
+            if self._fsm.state == FlightState.EXPLORING:
+                try:
+                    await self._fsm.transition(FlightState.INVESTIGATING)
+                except InvalidTransition:
+                    pass
+
+        elif exploration_state == "exploring":
+            if self._fsm.state == FlightState.INVESTIGATING:
+                try:
+                    await self._fsm.transition(FlightState.EXPLORING)
+                except InvalidTransition:
+                    pass

--- a/tests/test_exploration_tracker.py
+++ b/tests/test_exploration_tracker.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from breacheye.adapters.sim import SimAdapter
+from breacheye.bus import AsyncEventBus
+from breacheye.exploration_tracker import ExplorationTracker
+from breacheye.state_machine import FlightState, FlightStateMachine
+
+
+async def make_tracker() -> tuple[ExplorationTracker, FlightStateMachine, SimAdapter, AsyncEventBus]:
+    adapter = SimAdapter()
+    adapter.state.connected = True
+    adapter.state.battery = 100
+    bus = AsyncEventBus()
+    fsm = FlightStateMachine(adapter, bus)
+    await adapter.connect()
+    await fsm.transition(FlightState.TAKEOFF)
+    await fsm.transition(FlightState.EXPLORING)
+    tracker = ExplorationTracker(fsm, bus)
+    return tracker, fsm, adapter, bus
+
+
+def _nav_payload(exploration_state: str, reasoning: str = "clear corridor ahead") -> dict:
+    return {
+        "frame_id": 1,
+        "timestamp": 1746201234.0,
+        "decision": {
+            "action": "move_forward",
+            "params": {"distance_cm": 50},
+            "confidence": 0.85,
+            "reasoning": reasoning,
+            "exploration_state": exploration_state,
+        },
+    }
+
+
+async def test_coverage_complete_triggers_returning() -> None:
+    tracker, fsm, _, bus = await make_tracker()
+    await tracker.start()
+    try:
+        await bus.publish("drone.nav_decision", _nav_payload("coverage_complete"))
+        await asyncio.sleep(0.05)
+        assert fsm.state == FlightState.RETURNING
+    finally:
+        await tracker.stop()
+
+
+async def test_low_battery_nav_triggers_returning() -> None:
+    tracker, fsm, _, bus = await make_tracker()
+    await tracker.start()
+    try:
+        await bus.publish("drone.nav_decision", _nav_payload("low_battery"))
+        await asyncio.sleep(0.05)
+        assert fsm.state == FlightState.RETURNING
+    finally:
+        await tracker.stop()
+
+
+async def test_investigating_poi_triggers_investigating() -> None:
+    tracker, fsm, _, bus = await make_tracker()
+    await tracker.start()
+    try:
+        await bus.publish("drone.nav_decision", _nav_payload("investigating_poi"))
+        await asyncio.sleep(0.05)
+        assert fsm.state == FlightState.INVESTIGATING
+    finally:
+        await tracker.stop()
+
+
+async def test_exploring_from_investigating() -> None:
+    tracker, fsm, _, bus = await make_tracker()
+    # Manually move FSM to INVESTIGATING first
+    await fsm.transition(FlightState.INVESTIGATING)
+    await tracker.start()
+    try:
+        await bus.publish("drone.nav_decision", _nav_payload("exploring"))
+        await asyncio.sleep(0.05)
+        assert fsm.state == FlightState.EXPLORING
+    finally:
+        await tracker.stop()
+
+
+async def test_coverage_stats_tracked() -> None:
+    tracker, fsm, _, bus = await make_tracker()
+    await tracker.start()
+    try:
+        await bus.publish("drone.nav_decision", _nav_payload("exploring", reasoning="hallway A"))
+        await bus.publish("drone.nav_decision", _nav_payload("exploring", reasoning="room B"))
+        await bus.publish("drone.nav_decision", _nav_payload("exploring", reasoning="stairwell C"))
+        await asyncio.sleep(0.05)
+        assert tracker.coverage_stats["areas_visited"] > 0
+    finally:
+        await tracker.stop()
+
+
+async def test_record_poi_increments() -> None:
+    tracker, _, _, _ = await make_tracker()
+    tracker.record_poi()
+    tracker.record_poi()
+    tracker.record_poi()
+    assert tracker.coverage_stats["pois_found"] == 3
+
+
+async def test_exploration_event_published() -> None:
+    tracker, fsm, _, bus = await make_tracker()
+    event_queue = await bus.subscribe("drone.exploration_event")
+    await tracker.start()
+    try:
+        await bus.publish("drone.nav_decision", _nav_payload("coverage_complete"))
+        await asyncio.sleep(0.05)
+        assert not event_queue.empty()
+        event = event_queue.get_nowait()
+        assert event["event"] == "coverage_complete"
+        assert "stats" in event
+        assert "timestamp" in event
+    finally:
+        await tracker.stop()


### PR DESCRIPTION
## Summary
- `src/breacheye/exploration_tracker.py` — subscribes to `drone.nav_decision` bus topic, maps ExplorationState to FlightState transitions (coverage_complete/low_battery → RETURNING, investigating_poi ↔ EXPLORING). Tracks areas visited and POIs found. Publishes `drone.exploration_event`.
- 7 async tests covering all state transitions, coverage stats, POI counter, event publishing.

Closes #20.

## Test plan
- [x] `pytest tests/test_exploration_tracker.py -v` — 7/7 passed