### PR TITLE
feat: add operator command injection with pause/resume/abort

### DIFF
--- a/src/breacheye/operator.py
+++ b/src/breacheye/operator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict
+
+from breacheye.bus import AsyncEventBus
+from breacheye.state_machine import FlightStateMachine
+
+
+class OperatorAction(StrEnum):
+    ABORT = "abort"
+    PAUSE = "pause"
+    RESUME = "resume"
+
+
+class OperatorCommand(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    action: OperatorAction
+    issued_by: str = "operator"
+
+
+class OperatorHandler:
+    def __init__(self, fsm: FlightStateMachine, bus: AsyncEventBus) -> None:
+        self._fsm = fsm
+        self._bus = bus
+
+    async def handle(self, command: OperatorCommand) -> dict:
+        """Execute operator command. Returns result dict."""
+        if command.action == OperatorAction.ABORT:
+            await self._fsm.abort()
+            return {"action": "abort", "state": str(self._fsm.state), "success": True}
+        elif command.action == OperatorAction.PAUSE:
+            await self._fsm.pause()
+            return {"action": "pause", "paused": self._fsm.paused, "success": True}
+        elif command.action == OperatorAction.RESUME:
+            await self._fsm.resume()
+            return {"action": "resume", "paused": self._fsm.paused, "success": True}
+        else:
+            return {"action": str(command.action), "success": False, "reason": "unknown action"}

--- a/src/breacheye/service.py
+++ b/src/breacheye/service.py
@@ -14,7 +14,9 @@ from breacheye.adapters.sim import SimAdapter
 from breacheye.adapters.tello import TelloAdapter
 from breacheye.bus import AsyncEventBus
 from breacheye.models import CommandResult, CommandStatus, DroneCommand
+from breacheye.operator import OperatorCommand, OperatorHandler
 from breacheye.safety import SafetyController
+from breacheye.state_machine import FlightStateMachine
 from breacheye.video import FrameStore, TelloVideoPump
 
 log = logging.getLogger(__name__)
@@ -31,6 +33,7 @@ class HarnessRuntime:
         self.frame_store = FrameStore(sample_fps=1.0)
         self.adapter = make_adapter(mode)
         self.safety = SafetyController(self.adapter, self.bus)
+        self.fsm = FlightStateMachine(self.adapter, self.bus)
         self.video_pump: TelloVideoPump | None = None
         self._zmq_task: asyncio.Task | None = None
         self._zmq_socket = None
@@ -182,6 +185,11 @@ def create_app(mode: str = "sim") -> FastAPI:
             await runtime.bus.publish("drone.command_results", result)
             return result
 
+    @app.post("/operator-command")
+    async def operator_command(command: OperatorCommand):
+        handler = OperatorHandler(runtime.fsm, runtime.bus)
+        return await handler.handle(command)
+
     @app.get("/frame/latest")
     async def latest_frame():
         frame = runtime.frame_store.latest_sampled_jpeg()
@@ -199,7 +207,16 @@ def create_app(mode: str = "sim") -> FastAPI:
     @app.websocket("/events")
     async def events(websocket: WebSocket):
         await websocket.accept()
-        topics = ["drone.telemetry", "drone.command_results", "drone.frames.llm", "drone.detections"]
+        topics = [
+            "drone.telemetry",
+            "drone.command_results",
+            "drone.frames.llm",
+            "drone.detections",
+            "drone.state_change",
+            "drone.paused",
+            "drone.resumed",
+            "drone.abort",
+        ]
         queues = {topic: await runtime.bus.subscribe(topic) for topic in topics}
         tasks: set[asyncio.Task] = set()
         try:

--- a/src/breacheye/state_machine.py
+++ b/src/breacheye/state_machine.py
@@ -62,14 +62,45 @@ class FlightStateMachine:
         self._bus = bus
         self._state = FlightState.PREFLIGHT
         self._min_battery = 20
+        self._paused = False
 
     @property
     def state(self) -> FlightState:
         return self._state
 
+    @property
+    def paused(self) -> bool:
+        return self._paused
+
     def accepts_nav(self) -> bool:
         """Whether nav decisions from NavInterpreter should be executed."""
-        return self._state in (FlightState.EXPLORING, FlightState.INVESTIGATING)
+        return self._state in (FlightState.EXPLORING, FlightState.INVESTIGATING) and not self._paused
+
+    async def pause(self) -> None:
+        """Pause autonomous navigation. Drone hovers in place."""
+        if self._paused:
+            return
+        self._paused = True
+        if self._state in (FlightState.EXPLORING, FlightState.INVESTIGATING):
+            await self._adapter.hover()
+        await self._bus.publish("drone.paused", {"timestamp": time()})
+
+    async def resume(self) -> None:
+        """Resume autonomous navigation."""
+        if not self._paused:
+            return
+        self._paused = False
+        await self._bus.publish("drone.resumed", {"timestamp": time()})
+
+    async def abort(self) -> None:
+        """Emergency abort — transition to LANDING from any non-terminal state."""
+        if self._state == FlightState.COMPLETE:
+            return
+        await self._bus.publish("drone.abort", {"from_state": str(self._state), "timestamp": time()})
+        try:
+            await self.transition(FlightState.LANDING)
+        except InvalidTransition:
+            pass
 
     async def transition(self, target: FlightState) -> None:
         """Attempt state transition. Raises InvalidTransition on illegal moves."""

--- a/src/breacheye/state_machine.py
+++ b/src/breacheye/state_machine.py
@@ -94,8 +94,9 @@ class FlightStateMachine:
 
     async def abort(self) -> None:
         """Emergency abort — transition to LANDING from any non-terminal state."""
-        if self._state == FlightState.COMPLETE:
+        if self._state in (FlightState.COMPLETE, FlightState.PREFLIGHT):
             return
+        self._paused = False
         await self._bus.publish("drone.abort", {"from_state": str(self._state), "timestamp": time()})
         try:
             await self.transition(FlightState.LANDING)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+
+from breacheye.adapters.sim import SimAdapter
+from breacheye.bus import AsyncEventBus
+from breacheye.operator import OperatorAction, OperatorCommand, OperatorHandler
+from breacheye.state_machine import FlightState, FlightStateMachine
+
+
+async def make_handler(battery: int = 100):
+    adapter = SimAdapter()
+    adapter.state.connected = True
+    adapter.state.battery = battery
+    bus = AsyncEventBus()
+    fsm = FlightStateMachine(adapter, bus)
+    await adapter.connect()
+    handler = OperatorHandler(fsm, bus)
+    return handler, fsm, adapter, bus
+
+
+async def _to_exploring(fsm: FlightStateMachine) -> None:
+    await fsm.transition(FlightState.TAKEOFF)
+    await fsm.transition(FlightState.EXPLORING)
+
+
+async def _to_investigating(fsm: FlightStateMachine) -> None:
+    await fsm.transition(FlightState.TAKEOFF)
+    await fsm.transition(FlightState.EXPLORING)
+    await fsm.transition(FlightState.INVESTIGATING)
+
+
+async def _to_complete(fsm: FlightStateMachine) -> None:
+    await fsm.transition(FlightState.TAKEOFF)
+    await fsm.transition(FlightState.EXPLORING)
+    await fsm.transition(FlightState.RETURNING)
+    await fsm.transition(FlightState.LANDING)
+    await fsm.transition(FlightState.COMPLETE)
+
+
+# ---------------------------------------------------------------------------
+# pause / resume tests
+# ---------------------------------------------------------------------------
+
+
+async def test_pause_during_exploring() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    await fsm.pause()
+    assert fsm.paused is True
+    assert fsm.accepts_nav() is False
+
+
+async def test_resume_after_pause() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    await fsm.pause()
+    await fsm.resume()
+    assert fsm.paused is False
+    assert fsm.accepts_nav() is True
+
+
+# ---------------------------------------------------------------------------
+# abort tests
+# ---------------------------------------------------------------------------
+
+
+async def test_abort_from_exploring() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    await fsm.abort()
+    assert fsm.state == FlightState.LANDING
+
+
+async def test_abort_from_investigating() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_investigating(fsm)
+    await fsm.abort()
+    assert fsm.state == FlightState.LANDING
+
+
+async def test_abort_from_takeoff() -> None:
+    _, fsm, _, _ = await make_handler()
+    await fsm.transition(FlightState.TAKEOFF)
+    await fsm.abort()
+    assert fsm.state == FlightState.LANDING
+
+
+async def test_abort_from_complete_is_noop() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_complete(fsm)
+    await fsm.abort()
+    assert fsm.state == FlightState.COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# event publication tests
+# ---------------------------------------------------------------------------
+
+
+async def test_pause_publishes_event() -> None:
+    _, fsm, _, bus = await make_handler()
+    await _to_exploring(fsm)
+    queue = await bus.subscribe("drone.paused")
+    await fsm.pause()
+    assert not queue.empty()
+    event = queue.get_nowait()
+    assert "timestamp" in event
+
+
+async def test_resume_publishes_event() -> None:
+    _, fsm, _, bus = await make_handler()
+    await _to_exploring(fsm)
+    await fsm.pause()
+    queue = await bus.subscribe("drone.resumed")
+    await fsm.resume()
+    assert not queue.empty()
+    event = queue.get_nowait()
+    assert "timestamp" in event
+
+
+async def test_abort_publishes_event() -> None:
+    _, fsm, _, bus = await make_handler()
+    await _to_exploring(fsm)
+    queue = await bus.subscribe("drone.abort")
+    await fsm.abort()
+    assert not queue.empty()
+    event = queue.get_nowait()
+    assert "from_state" in event
+    assert "timestamp" in event
+
+
+# ---------------------------------------------------------------------------
+# OperatorHandler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_abort() -> None:
+    handler, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    result = await handler.handle(OperatorCommand(action=OperatorAction.ABORT))
+    assert result["action"] == "abort"
+    assert result["success"] is True
+    assert result["state"] == str(FlightState.LANDING)
+
+
+async def test_handler_pause_resume() -> None:
+    handler, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+
+    pause_result = await handler.handle(OperatorCommand(action=OperatorAction.PAUSE))
+    assert pause_result["action"] == "pause"
+    assert pause_result["success"] is True
+    assert pause_result["paused"] is True
+
+    resume_result = await handler.handle(OperatorCommand(action=OperatorAction.RESUME))
+    assert resume_result["action"] == "resume"
+    assert resume_result["success"] is True
+    assert resume_result["paused"] is False
+
+
+# ---------------------------------------------------------------------------
+# idempotency tests
+# ---------------------------------------------------------------------------
+
+
+async def test_double_pause_is_idempotent() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    await fsm.pause()
+    await fsm.pause()
+    assert fsm.paused is True
+
+
+async def test_double_resume_is_idempotent() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    # resume without pausing first — should not error
+    await fsm.resume()
+    assert fsm.paused is False

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -93,6 +93,22 @@ async def test_abort_from_complete_is_noop() -> None:
     assert fsm.state == FlightState.COMPLETE
 
 
+async def test_abort_from_preflight_is_noop() -> None:
+    _, fsm, _, _ = await make_handler()
+    assert fsm.state == FlightState.PREFLIGHT
+    await fsm.abort()
+    assert fsm.state == FlightState.PREFLIGHT
+
+
+async def test_abort_clears_paused_flag() -> None:
+    _, fsm, _, _ = await make_handler()
+    await _to_exploring(fsm)
+    await fsm.pause()
+    assert fsm.paused is True
+    await fsm.abort()
+    assert fsm.paused is False
+
+
 # ---------------------------------------------------------------------------
 # event publication tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `src/breacheye/state_machine.py` — adds `_paused` flag, `pause()`/`resume()`/`abort()` methods. `accepts_nav()` now gates on pause state.
- `src/breacheye/operator.py` — `OperatorCommand` model + `OperatorHandler` dispatching ABORT/PAUSE/RESUME.
- `src/breacheye/service.py` — `POST /operator-command` endpoint, FSM added to HarnessRuntime, WS topics extended with state_change/paused/resumed/abort.
- 13 async tests covering all operator actions, event publishing, idempotency, abort from every reachable state.

Closes #18.

## Test plan
- [x] `pytest tests/test_operator.py tests/test_state_machine.py -v` — 30/30 passed (no regressions)