### PR TITLE
feat: add demo launcher with auto-fallback degradation

### DIFF
--- a/src/breacheye/cli.py
+++ b/src/breacheye/cli.py
@@ -57,6 +57,17 @@ def main() -> None:
     fly.add_argument("--auto-takeoff", action="store_true", help="Issue takeoff once the loop is running.")
     fly.add_argument("--duration-s", type=float, help="Stop the launched loop after this many seconds.")
 
+    demo = subparsers.add_parser("demo", help="Launch demo with auto-fallback (live -> recorded -> mock).")
+    demo.add_argument("--mode", choices=["live", "recorded", "mock"], default="live",
+                      help="Demo mode (default: live, auto-degrades if needed)")
+    demo.add_argument("--host", default="127.0.0.1")
+    demo.add_argument("--port", type=int, default=8000)
+    demo.add_argument("--fps", type=float, default=5.0)
+    demo.add_argument("--video", help="Video file for recorded mode (default: demo/sample.mp4)")
+    demo.add_argument("--log-dir", default="logs")
+    demo.add_argument("--run-id")
+    demo.add_argument("--duration-s", type=float, help="Stop demo after N seconds.")
+
     args = parser.parse_args()
     if args.command == "serve":
         app = create_app(mode=args.mode)
@@ -87,6 +98,17 @@ def main() -> None:
                 duration_s=args.duration_s,
             )
         )
+    elif args.command == "demo":
+        raise SystemExit(_demo(
+            mode=args.mode,
+            host=args.host,
+            port=args.port,
+            fps=args.fps,
+            video=args.video,
+            log_dir=args.log_dir,
+            run_id=args.run_id,
+            duration_s=args.duration_s,
+        ))
 
 
 async def _smoke(mode: str) -> None:
@@ -156,6 +178,31 @@ def _fly(
             auto_takeoff=auto_takeoff,
             duration_s=duration_s,
         )
+    )
+
+
+def _demo(
+    *,
+    mode: str,
+    host: str,
+    port: int,
+    fps: float,
+    video: str | None,
+    log_dir: str,
+    run_id: str | None,
+    duration_s: float | None,
+) -> int:
+    from breacheye.flight import run_demo
+
+    return run_demo(
+        mode=mode,
+        host=host,
+        port=port,
+        fps=fps,
+        video_path=video,
+        log_dir=log_dir,
+        run_id=run_id,
+        duration_s=duration_s,
     )
 
 

--- a/src/breacheye/flight.py
+++ b/src/breacheye/flight.py
@@ -267,6 +267,176 @@ def _stop_flight_processes(procs: Sequence[tuple[str, subprocess.Popen]], base_u
     _stop_processes(harness)
 
 
+def build_demo_specs(
+    mode: str,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    fps: float = 5.0,
+    video_path: str | None = None,
+    log_dir: str = "logs",
+    run_id: str | None = None,
+) -> list[ProcessSpec]:
+    base_url = f"http://{host}:{port}"
+    root = _repo_root()
+    specs: list[ProcessSpec] = []
+
+    # Harness is always first
+    harness_mode = "tello" if mode == "live" else "sim"
+    specs.append(ProcessSpec(
+        "harness",
+        [sys.executable, "-m", "breacheye.cli", "serve",
+         "--mode", harness_mode, "--host", host, "--port", str(port)],
+    ))
+
+    if mode == "live":
+        specs.append(ProcessSpec(
+            "rafa",
+            [sys.executable, "-m", "breacheye.cli", "rafa",
+             "--mode", "models", "--log-dir", log_dir, *_run_id_args(run_id)],
+        ))
+        specs.append(ProcessSpec(
+            "frame_publisher",
+            [sys.executable, str(root / "integration" / "frame_publisher.py"),
+             "--fps", str(fps), "--tello", "--log-dir", log_dir, *_run_id_args(run_id)],
+        ))
+    elif mode == "recorded":
+        playback_args = [
+            sys.executable, str(root / "demo" / "playback.py"),
+            "--video", video_path or str(root / "demo" / "sample.mp4"),
+            "--detections", str(root / "demo" / "mock_detections.json"),
+            "--loop",
+        ]
+        if fps:
+            playback_args.extend(["--fps", str(fps)])
+        specs.append(ProcessSpec("playback", playback_args))
+        specs.append(ProcessSpec(
+            "mock_navigation",
+            [sys.executable, str(root / "demo" / "mock_navigation.py"),
+             "--frames", "999999", "--pattern", "room_sweep", "--fps", "2"],
+        ))
+        specs.append(ProcessSpec(
+            "mock_telemetry",
+            [sys.executable, str(root / "demo" / "mock_telemetry.py"),
+             "--frames", "999999", "--fps", "1"],
+        ))
+    elif mode == "mock":
+        specs.append(ProcessSpec(
+            "frame_publisher",
+            [sys.executable, str(root / "integration" / "frame_publisher.py"),
+             "--fps", str(fps), "--log-dir", log_dir, *_run_id_args(run_id)],
+        ))
+        specs.append(ProcessSpec(
+            "mock_detections",
+            [sys.executable, str(root / "demo" / "mock_detections.py"),
+             "--frames", "999999", "--fps", "10"],
+        ))
+        specs.append(ProcessSpec(
+            "mock_navigation",
+            [sys.executable, str(root / "demo" / "mock_navigation.py"),
+             "--frames", "999999", "--pattern", "room_sweep", "--fps", "2"],
+        ))
+        specs.append(ProcessSpec(
+            "mock_telemetry",
+            [sys.executable, str(root / "demo" / "mock_telemetry.py"),
+             "--frames", "999999", "--fps", "1"],
+        ))
+
+    # Nav interpreter in ALL modes — bridges ZMQ 5558 → harness /commands
+    specs.append(ProcessSpec(
+        "nav_interpreter",
+        [sys.executable, "-m", "breacheye.cli", "nav",
+         "--command-url", f"{base_url}/commands", "--log-dir", log_dir, *_run_id_args(run_id)],
+    ))
+
+    return specs
+
+
+def run_demo(
+    mode: str = "live",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    fps: float = 5.0,
+    video_path: str | None = None,
+    log_dir: str = "logs",
+    run_id: str | None = None,
+    duration_s: float | None = None,
+) -> int:
+    run_id = run_id or time.strftime("demo-%Y%m%dT%H%M%SZ", time.gmtime())
+    resolved_mode = _resolve_demo_mode(mode, video_path)
+
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"  BreachEye Demo — mode: {resolved_mode}", flush=True)
+    if resolved_mode != mode:
+        print(f"  (auto-degraded from {mode})", flush=True)
+    print(f"  harness: http://{host}:{port}", flush=True)
+    print(f"{'=' * 60}\n", flush=True)
+
+    base_url = f"http://{host}:{port}"
+    os.environ["BREACHEYE_RUN_ID"] = run_id
+    os.environ["BREACHEYE_LOG_DIR"] = log_dir
+    if resolved_mode == "live":
+        _apply_local_model_defaults(os.environ, "models")
+
+    specs = build_demo_specs(resolved_mode, host, port, fps, video_path, log_dir, run_id)
+    procs: list[tuple[str, subprocess.Popen]] = []
+
+    try:
+        for spec in specs:
+            print(f"[demo] starting {spec.name}", flush=True)
+            procs.append((spec.name, subprocess.Popen(spec.argv, env=os.environ.copy(), start_new_session=True)))
+            if spec.name == "harness":
+                _wait_for_harness(base_url)
+            elif spec.name in ("rafa", "playback"):
+                time.sleep(0.75)
+            elif spec.name == "frame_publisher":
+                time.sleep(0.5)
+
+        print("\n[demo] all components running — Ctrl+C to stop\n", flush=True)
+
+        deadline = time.monotonic() + duration_s if duration_s else None
+        while True:
+            for name, proc in procs:
+                code = proc.poll()
+                if code is not None:
+                    print(f"[demo] {name} exited with {code}", flush=True)
+                    return code
+            if deadline and time.monotonic() >= deadline:
+                print("[demo] duration reached; stopping", flush=True)
+                return 0
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        print("\n[demo] interrupted; stopping", flush=True)
+        return 130
+    finally:
+        _stop_flight_processes(procs, base_url)
+
+
+def _resolve_demo_mode(mode: str, video_path: str | None) -> str:
+    if mode == "live":
+        if not _check_tello_connection():
+            print("[demo] WARNING: Tello not available — falling back to recorded mode", flush=True)
+            mode = "recorded"
+    if mode == "recorded":
+        vpath = video_path or str(_repo_root() / "demo" / "sample.mp4")
+        if not Path(vpath).exists():
+            print(f"[demo] WARNING: video not found ({vpath}) — falling back to mock mode", flush=True)
+            mode = "mock"
+    return mode
+
+
+def _check_tello_connection(timeout: float = 5.0) -> bool:
+    """Try connecting to Tello. Returns True if successful within timeout."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c",
+             "from djitellopy import Tello; t = Tello(); t.connect(); print('ok')"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return result.returncode == 0 and "ok" in result.stdout
+    except (subprocess.TimeoutExpired, Exception):
+        return False
+
+
 def _stop_processes(procs: Sequence[tuple[str, subprocess.Popen]]) -> None:
     for name, proc in reversed(procs):
         if proc.poll() is not None:

--- a/tests/test_demo_launcher.py
+++ b/tests/test_demo_launcher.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from breacheye.flight import build_demo_specs, _resolve_demo_mode
+
+
+def test_mock_mode_specs():
+    specs = build_demo_specs("mock")
+    names = [s.name for s in specs]
+    assert "harness" in names
+    assert "frame_publisher" in names
+    assert "mock_detections" in names
+    assert "mock_navigation" in names
+    assert "mock_telemetry" in names
+    assert "nav_interpreter" in names
+    # No rafa or playback in mock mode
+    assert "rafa" not in names
+    assert "playback" not in names
+
+
+def test_recorded_mode_specs():
+    specs = build_demo_specs("recorded")
+    names = [s.name for s in specs]
+    assert "harness" in names
+    assert "playback" in names
+    assert "mock_navigation" in names
+    assert "mock_telemetry" in names
+    assert "nav_interpreter" in names
+    # No frame_publisher or rafa or mock_detections
+    assert "frame_publisher" not in names
+    assert "rafa" not in names
+    assert "mock_detections" not in names
+
+
+def test_live_mode_specs():
+    specs = build_demo_specs("live")
+    names = [s.name for s in specs]
+    assert "harness" in names
+    assert "rafa" in names
+    assert "frame_publisher" in names
+    assert "nav_interpreter" in names
+    # No mocks in live
+    assert "playback" not in names
+    assert "mock_detections" not in names
+
+
+def test_harness_mode_sim_for_mock():
+    specs = build_demo_specs("mock")
+    harness = [s for s in specs if s.name == "harness"][0]
+    assert "--mode" in harness.argv
+    idx = harness.argv.index("--mode")
+    assert harness.argv[idx + 1] == "sim"
+
+
+def test_harness_mode_tello_for_live():
+    specs = build_demo_specs("live")
+    harness = [s for s in specs if s.name == "harness"][0]
+    idx = harness.argv.index("--mode")
+    assert harness.argv[idx + 1] == "tello"
+
+
+def test_resolve_recorded_degrades_to_mock_if_no_video():
+    resolved = _resolve_demo_mode("recorded", "/nonexistent/video.mp4")
+    assert resolved == "mock"
+
+
+def test_nav_interpreter_in_all_modes():
+    for mode in ("live", "recorded", "mock"):
+        specs = build_demo_specs(mode)
+        names = [s.name for s in specs]
+        assert "nav_interpreter" in names, f"nav_interpreter missing in {mode} mode"


### PR DESCRIPTION
## Summary
- `breacheye demo` subcommand with `--mode live|recorded|mock` (default: live)
- Auto-fallback chain: live → recorded (if Tello fails 5s check) → mock (if video missing)
- `build_demo_specs()` returns correct ProcessSpec per mode — playback replaces frame_publisher + rafa in recorded mode
- Nav interpreter included in all modes to drive the state machine
- Startup banner shows resolved mode + degradation notice
- Same subprocess lifecycle as `breacheye fly` — sequential start, health polling, graceful shutdown

Closes #29.

## Test plan
- [x] `pytest tests/test_demo_launcher.py -v` — 7/7 passed
- [ ] `breacheye demo --mode mock --duration-s 10` — verify all components launch and clean shutdown
- [ ] `breacheye demo --mode recorded --video nonexistent.mp4` — verify auto-degrade to mock