### PR TITLE
feat: three-zone layout + header + status bar + glassmorphism — link #57

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -254,10 +254,10 @@
 /* ── Telemetry HUD ───────────────────────────────────────── */
 
 .flight-controls {
-  border: 1px solid rgba(248, 113, 113, 0.28);
-  border-radius: 6px;
-  background: rgba(127, 29, 29, 0.18);
-  backdrop-filter: blur(8px);
+  /* Border/bg/blur handled by parent .glass-panel wrapper */
+  border: 1px solid rgba(248, 113, 113, 0.20);
+  border-radius: 0;
+  background: rgba(127, 29, 29, 0.12);
   overflow: hidden;
 }
 
@@ -426,10 +426,7 @@
 .tactical-map {
   height: 100%;
   min-height: 200px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
-  backdrop-filter: blur(8px);
+  /* Border/bg/blur handled by parent .glass-panel wrapper */
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -462,10 +459,7 @@
 .map3d {
   height: 100%;
   min-height: 220px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
-  backdrop-filter: blur(8px);
+  /* Border/bg/blur handled by parent .glass-panel wrapper */
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -509,6 +503,23 @@
   display: block;
   width: 100%;
   height: 100%;
+}
+
+/* ── Glassmorphism ───────────────────────────────────────── */
+
+.glass-panel {
+  background: rgb(15 23 42 / 0.95);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.36);
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  .glass-panel {
+    background: rgb(15 23 42 / 0.75);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+  }
 }
 
 /* ── Responsive: 1920×1080 primary target ───────────────── */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -22,24 +22,6 @@
   z-index: 10;
 }
 
-/* ── Bottom bar ───────────────────────────────────────────── */
-
-.app__bottom-bar {
-  display: flex;
-  align-items: center;
-  padding: 0 16px;
-  border-top: 1px solid var(--border);
-  background: rgba(10, 10, 15, 0.95);
-  backdrop-filter: blur(12px);
-  z-index: 10;
-}
-
-.app__bottom-placeholder {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.1em;
-  color: var(--text-muted);
-}
 
 .app__header-left {
   display: flex;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,12 +14,31 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 24px;
-  height: 52px;
+  /* height controlled by Tailwind h-12 (48px) in JSX */
   border-bottom: 1px solid var(--border);
   background: rgba(10, 10, 15, 0.95);
   backdrop-filter: blur(12px);
   flex-shrink: 0;
   z-index: 10;
+}
+
+/* ── Bottom bar ───────────────────────────────────────────── */
+
+.app__bottom-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  border-top: 1px solid var(--border);
+  background: rgba(10, 10, 15, 0.95);
+  backdrop-filter: blur(12px);
+  z-index: 10;
+}
+
+.app__bottom-placeholder {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
 }
 
 .app__header-left {
@@ -423,7 +442,7 @@
 /* ── Tactical Map ────────────────────────────────────────── */
 
 .tactical-map {
-  flex: 1;
+  height: 100%;
   min-height: 200px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 6px;
@@ -459,7 +478,7 @@
 }
 
 .map3d {
-  flex: 1;
+  height: 100%;
   min-height: 220px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 6px;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react'
 import { WebSocketProvider } from './contexts/WebSocketContext'
+import AppHeader from './components/AppHeader'
 import VideoPanel from './components/VideoPanel'
 import DetectionOverlay from './components/DetectionOverlay'
 import FlightControls from './components/FlightControls'
-import TelemetryHUD from './components/TelemetryHUD'
 import TacticalMap from './components/TacticalMap'
 import Map3D from './components/Map3D'
 import './App.css'
@@ -17,15 +17,7 @@ export default function App() {
       <div className="h-screen w-screen flex flex-col overflow-hidden bg-[var(--bg-base)]">
 
         {/* Header — 48px fixed */}
-        <header className="app__header h-12 flex-shrink-0">
-          <div className="app__header-left">
-            <span className="app__logo">BREACHEYE</span>
-            <span className="app__tagline">Autonomous Indoor Mapping · NatSec 2026</span>
-          </div>
-          <div className="app__header-right">
-            <span className="app__badge">TACTICAL COP</span>
-          </div>
-        </header>
+        <AppHeader />
 
         {/* Main — flex row, fills remaining height between header and bottom bar */}
         <main className="flex-1 flex flex-row overflow-hidden">
@@ -43,11 +35,6 @@ export default function App() {
             {/* Flight controls — fixed height content */}
             <div className="flex-shrink-0">
               <FlightControls />
-            </div>
-
-            {/* Telemetry HUD — hidden from sidebar, data feeds header */}
-            <div className="hidden">
-              <TelemetryHUD />
             </div>
 
             {/* Tactical Map — flex-1 fills remaining space */}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,17 +34,17 @@ export default function App() {
           {/* Zone B — right sidebar: controls (fixed) + tactical map (flex) */}
           <aside className="w-[320px] flex flex-col flex-shrink-0 p-4 pl-0 gap-3">
             {/* Flight controls — fixed height content */}
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 glass-panel overflow-hidden">
               <FlightControls />
             </div>
 
             {/* Tactical Map — flex-1 fills remaining space */}
-            <div className="flex-1 min-h-0">
+            <div className="flex-1 min-h-0 glass-panel overflow-hidden">
               <TacticalMap />
             </div>
 
             {/* 3D Map */}
-            <div className="flex-1 min-h-0">
+            <div className="flex-1 min-h-0 glass-panel overflow-hidden">
               <Map3D />
             </div>
           </aside>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react'
+import { WebSocketProvider } from './contexts/WebSocketContext'
 import VideoPanel from './components/VideoPanel'
 import DetectionOverlay from './components/DetectionOverlay'
 import FlightControls from './components/FlightControls'
@@ -11,32 +12,34 @@ export default function App() {
   const videoFrameRef = useRef(null)
 
   return (
-    <div className="app">
-      <header className="app__header">
-        <div className="app__header-left">
-          <span className="app__logo">BREACHEYE</span>
-          <span className="app__tagline">Autonomous Indoor Mapping · NatSec 2026</span>
-        </div>
-        <div className="app__header-right">
-          <span className="app__badge">TACTICAL COP</span>
-        </div>
-      </header>
-
-      <main className="app__body">
-        <section className="app__video">
-          <div className="video-overlay-container">
-            <VideoPanel frameRef={videoFrameRef} />
-            <DetectionOverlay containerRef={videoFrameRef} />
+    <WebSocketProvider>
+      <div className="app">
+        <header className="app__header">
+          <div className="app__header-left">
+            <span className="app__logo">BREACHEYE</span>
+            <span className="app__tagline">Autonomous Indoor Mapping · NatSec 2026</span>
           </div>
-        </section>
+          <div className="app__header-right">
+            <span className="app__badge">TACTICAL COP</span>
+          </div>
+        </header>
 
-        <aside className="app__sidebar">
-          <FlightControls />
-          <TelemetryHUD />
-          <TacticalMap />
-          <Map3D />
-        </aside>
-      </main>
-    </div>
+        <main className="app__body">
+          <section className="app__video">
+            <div className="video-overlay-container">
+              <VideoPanel frameRef={videoFrameRef} />
+              <DetectionOverlay containerRef={videoFrameRef} />
+            </div>
+          </section>
+
+          <aside className="app__sidebar">
+            <FlightControls />
+            <TelemetryHUD />
+            <TacticalMap />
+            <Map3D />
+          </aside>
+        </main>
+      </div>
+    </WebSocketProvider>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,8 +13,11 @@ export default function App() {
 
   return (
     <WebSocketProvider>
-      <div className="app">
-        <header className="app__header">
+      {/* Full viewport column flex */}
+      <div className="h-screen w-screen flex flex-col overflow-hidden bg-[var(--bg-base)]">
+
+        {/* Header — 48px fixed */}
+        <header className="app__header h-12 flex-shrink-0">
           <div className="app__header-left">
             <span className="app__logo">BREACHEYE</span>
             <span className="app__tagline">Autonomous Indoor Mapping · NatSec 2026</span>
@@ -24,21 +27,46 @@ export default function App() {
           </div>
         </header>
 
-        <main className="app__body">
-          <section className="app__video">
-            <div className="video-overlay-container">
+        {/* Main — flex row, fills remaining height between header and bottom bar */}
+        <main className="flex-1 flex flex-row overflow-hidden">
+
+          {/* Zone A — video + detection overlay, left column */}
+          <section className="flex-1 min-w-0 p-4">
+            <div className="video-overlay-container h-full">
               <VideoPanel frameRef={videoFrameRef} />
               <DetectionOverlay containerRef={videoFrameRef} />
             </div>
           </section>
 
-          <aside className="app__sidebar">
-            <FlightControls />
-            <TelemetryHUD />
-            <TacticalMap />
-            <Map3D />
+          {/* Zone B — right sidebar: controls (fixed) + tactical map (flex) */}
+          <aside className="w-[320px] flex flex-col flex-shrink-0 p-4 pl-0 gap-3">
+            {/* Flight controls — fixed height content */}
+            <div className="flex-shrink-0">
+              <FlightControls />
+            </div>
+
+            {/* Telemetry HUD — hidden from sidebar, data feeds header */}
+            <div className="hidden">
+              <TelemetryHUD />
+            </div>
+
+            {/* Tactical Map — flex-1 fills remaining space */}
+            <div className="flex-1 min-h-0">
+              <TacticalMap />
+            </div>
+
+            {/* 3D Map */}
+            <div className="flex-1 min-h-0">
+              <Map3D />
+            </div>
           </aside>
         </main>
+
+        {/* Zone C — bottom bar, 32px fixed */}
+        <footer className="h-8 flex-shrink-0 app__bottom-bar">
+          <span className="app__bottom-placeholder">ZONE C · STATUS BAR</span>
+        </footer>
+
       </div>
     </WebSocketProvider>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 import { WebSocketProvider } from './contexts/WebSocketContext'
 import AppHeader from './components/AppHeader'
+import BottomBar from './components/BottomBar'
 import VideoPanel from './components/VideoPanel'
 import DetectionOverlay from './components/DetectionOverlay'
 import FlightControls from './components/FlightControls'
@@ -50,9 +51,7 @@ export default function App() {
         </main>
 
         {/* Zone C — bottom bar, 32px fixed */}
-        <footer className="h-8 flex-shrink-0 app__bottom-bar">
-          <span className="app__bottom-placeholder">ZONE C · STATUS BAR</span>
-        </footer>
+        <BottomBar />
 
       </div>
     </WebSocketProvider>

--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -1,0 +1,102 @@
+import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
+import { formatFlightTime } from './TelemetryHUD'
+
+function TelemetryChip({ label, value, valueStyle }) {
+  return (
+    <div className="flex items-center gap-1.5 px-2.5 py-1 rounded border border-white/10 bg-white/5">
+      <span
+        className="font-ui text-[11px] uppercase tracking-[0.14em]"
+        style={{ color: 'var(--color-text-secondary)' }}
+      >
+        {label}
+      </span>
+      <span
+        className="font-mono text-[13px] font-medium"
+        style={{ color: 'var(--color-text-primary)', ...valueStyle }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function batteryColor(battery) {
+  if (battery === null || battery === undefined) return undefined
+  if (battery > 50) return 'var(--color-status-normal)'
+  if (battery >= 20) return 'var(--color-status-caution)'
+  return 'var(--color-status-critical)'
+}
+
+function statusDotColor(connectionState) {
+  switch (connectionState) {
+    case CONNECTION_STATE.CONNECTED:
+      return 'var(--color-status-normal)'
+    case CONNECTION_STATE.RECONNECTING:
+      return 'var(--color-status-caution)'
+    default:
+      return 'var(--color-status-off)'
+  }
+}
+
+export default function AppHeader() {
+  const { data: telemetry, connectionState } = useWebSocket('drone.telemetry')
+
+  const bat = telemetry?.battery ?? null
+  const alt = telemetry?.height_cm ?? null
+  const ft = telemetry?.flight_time_s ?? null
+
+  const batDisplay = bat !== null ? `${bat}%` : '--'
+  const altDisplay = alt !== null ? `${alt}cm` : '--'
+  const ftDisplay = formatFlightTime(ft)
+
+  return (
+    <header
+      className="h-12 flex-shrink-0 flex items-center justify-between px-6 z-10"
+      style={{
+        borderBottom: '1px solid var(--color-border-default)',
+        background: 'rgba(10, 10, 15, 0.95)',
+        backdropFilter: 'blur(12px)',
+      }}
+    >
+      {/* Left: logo */}
+      <div className="flex items-baseline gap-4">
+        <span
+          className="font-ui font-semibold uppercase text-[15px]"
+          style={{
+            letterSpacing: '0.14em',
+            color: 'var(--color-accent-blue)',
+          }}
+        >
+          BREACHEYE
+        </span>
+        <span
+          className="font-ui text-[11px]"
+          style={{
+            color: 'var(--color-text-subtle)',
+            letterSpacing: '0.05em',
+          }}
+        >
+          Autonomous Indoor Mapping · NatSec 2026
+        </span>
+      </div>
+
+      {/* Right: telemetry chips + connection dot */}
+      <div className="flex items-center gap-2">
+        <TelemetryChip
+          label="BAT"
+          value={batDisplay}
+          valueStyle={{ color: batteryColor(bat) }}
+        />
+        <TelemetryChip label="ALT" value={altDisplay} />
+        <TelemetryChip label="T" value={ftDisplay} />
+
+        {/* Connection status dot */}
+        <div
+          className="w-2 h-2 rounded-full ml-2 flex-shrink-0"
+          style={{ background: statusDotColor(connectionState) }}
+          title={connectionState}
+        />
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -1,5 +1,5 @@
 import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
-import { formatFlightTime } from './TelemetryHUD'
+import { batteryColor, formatFlightTime } from '../lib/telemetry'
 
 function TelemetryChip({ label, value, valueStyle }) {
   return (
@@ -18,13 +18,6 @@ function TelemetryChip({ label, value, valueStyle }) {
       </span>
     </div>
   )
-}
-
-function batteryColor(battery) {
-  if (battery === null || battery === undefined) return undefined
-  if (battery > 50) return 'var(--color-status-normal)'
-  if (battery >= 20) return 'var(--color-status-caution)'
-  return 'var(--color-status-critical)'
 }
 
 function statusDotColor(connectionState) {

--- a/frontend/src/components/BottomBar.jsx
+++ b/frontend/src/components/BottomBar.jsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
+
+function Separator() {
+  return <span className="h-4 border-l border-white/10 mx-2" />
+}
+
+function StatusItem({ label, value, valueStyle }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className="font-ui text-[11px] uppercase tracking-[0.14em]"
+        style={{ color: 'var(--color-text-subtle)' }}
+      >
+        {label}
+      </span>
+      <span
+        className="font-mono text-[11px] font-medium"
+        style={{ color: 'var(--color-text-secondary)', ...valueStyle }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function wsHealthLabel(connectionState) {
+  switch (connectionState) {
+    case CONNECTION_STATE.CONNECTED:
+      return { text: 'LIVE', color: 'var(--color-status-normal)' }
+    case CONNECTION_STATE.RECONNECTING:
+      return { text: 'RECONNECTING', color: 'var(--color-status-caution)' }
+    default:
+      return { text: 'OFFLINE', color: 'var(--color-status-off)' }
+  }
+}
+
+export default function BottomBar() {
+  const { data: telemetry, connectionState } = useWebSocket('drone.telemetry')
+  const { data: detectionsData } = useWebSocket('drone.detections')
+  const [view3D, setView3D] = useState(false)
+
+  const connected = telemetry?.connected ?? false
+  const flying = telemetry?.flying ?? false
+  const mode = flying ? 'AIRBORNE' : 'GROUNDED'
+  const modeColor = flying ? 'var(--color-accent-blue)' : 'var(--color-text-subtle)'
+
+  const linkColor = connected
+    ? 'var(--color-status-normal)'
+    : 'var(--color-status-off)'
+
+  const poiCount = Array.isArray(detectionsData?.detections)
+    ? detectionsData.detections.length
+    : 0
+
+  const wsHealth = wsHealthLabel(connectionState)
+
+  return (
+    <footer
+      className="h-8 flex-shrink-0 flex items-center justify-between px-4 z-10"
+      style={{
+        borderTop: '1px solid var(--color-border-default)',
+        background: 'var(--color-bg-deeper)',
+        backdropFilter: 'blur(12px)',
+      }}
+    >
+      {/* Left: system indicators */}
+      <div className="flex items-center">
+        <StatusItem
+          label="LINK"
+          value={connected ? 'UP' : 'DOWN'}
+          valueStyle={{ color: linkColor }}
+        />
+        <Separator />
+        <StatusItem
+          label="MODE"
+          value={mode}
+          valueStyle={{ color: modeColor }}
+        />
+        <Separator />
+        <StatusItem
+          label="POI"
+          value={String(poiCount)}
+        />
+        <Separator />
+        {/* WS health */}
+        <div className="flex items-center gap-1.5">
+          <span
+            className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+            style={{ background: wsHealth.color }}
+          />
+          <span
+            className="font-mono text-[11px] font-medium"
+            style={{ color: wsHealth.color }}
+          >
+            {wsHealth.text}
+          </span>
+        </div>
+      </div>
+
+      {/* Right: 3D toggle placeholder */}
+      <button
+        type="button"
+        onClick={() => setView3D((v) => !v)}
+        className="flex items-center gap-1.5 px-2 py-0.5 rounded border transition-colors"
+        style={{
+          borderColor: view3D
+            ? 'var(--color-accent-blue)'
+            : 'var(--color-border-default)',
+          background: view3D ? 'rgba(86, 124, 219, 0.15)' : 'transparent',
+          color: view3D
+            ? 'var(--color-accent-blue)'
+            : 'var(--color-text-secondary)',
+        }}
+      >
+        <span className="font-mono text-[11px] font-medium">[3D]</span>
+      </button>
+    </footer>
+  )
+}

--- a/frontend/src/components/BottomBar.jsx
+++ b/frontend/src/components/BottomBar.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
 
 function Separator() {
@@ -38,7 +37,6 @@ function wsHealthLabel(connectionState) {
 export default function BottomBar() {
   const { data: telemetry, connectionState } = useWebSocket('drone.telemetry')
   const { data: detectionsData } = useWebSocket('drone.detections')
-  const [view3D, setView3D] = useState(false)
 
   const connected = telemetry?.connected ?? false
   const flying = telemetry?.flying ?? false
@@ -101,16 +99,13 @@ export default function BottomBar() {
       {/* Right: 3D toggle placeholder */}
       <button
         type="button"
-        onClick={() => setView3D((v) => !v)}
-        className="flex items-center gap-1.5 px-2 py-0.5 rounded border transition-colors"
+        disabled
+        className="flex items-center gap-1.5 px-2 py-0.5 rounded border opacity-50 cursor-not-allowed"
+        title="3D view coming soon"
         style={{
-          borderColor: view3D
-            ? 'var(--color-accent-blue)'
-            : 'var(--color-border-default)',
-          background: view3D ? 'rgba(86, 124, 219, 0.15)' : 'transparent',
-          color: view3D
-            ? 'var(--color-accent-blue)'
-            : 'var(--color-text-secondary)',
+          borderColor: 'var(--color-border-default)',
+          background: 'transparent',
+          color: 'var(--color-text-secondary)',
         }}
       >
         <span className="font-mono text-[11px] font-medium">[3D]</span>

--- a/frontend/src/components/DetectionOverlay.jsx
+++ b/frontend/src/components/DetectionOverlay.jsx
@@ -1,9 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react'
-
-// NOTE: This component creates its own WebSocket connection to /events.
-// When TelemetryHUD (PR #33) is merged, consolidate both into a shared
-// useWebSocket hook to avoid duplicate connections.
-const WS_URL = 'ws://127.0.0.1:8000/events'
+import { useWebSocket } from '../contexts/WebSocketContext'
 
 // Source resolution for coordinate scaling
 const SRC_W = 960
@@ -48,9 +44,7 @@ export default function DetectionOverlay({ containerRef }) {
   const ctxRef = useRef(null)
   const detectionsRef = useRef([])
   const rafRef = useRef(null)
-  const wsRef = useRef(null)
-  const backoffRef = useRef(1000)
-  const reconnectRef = useRef(null)
+  const { data } = useWebSocket('drone.detections')
 
   const drawFrame = useCallback(() => {
     const canvas = canvasRef.current
@@ -175,61 +169,25 @@ export default function DetectionOverlay({ containerRef }) {
     return () => ro.disconnect()
   }, [containerRef])
 
-  // WebSocket subscription
+  // Handle incoming detections from shared WebSocket context
   useEffect(() => {
-    let ws
+    const msg = data
+    if (!Array.isArray(msg?.detections)) return
 
-    function connect() {
-      ws = new WebSocket(WS_URL)
-      wsRef.current = ws
+    const now = Date.now()
+    const incoming = msg.detections.map((detection) => ({
+      detection,
+      arrivedAt: now,
+    }))
 
-      ws.onopen = () => {
-        backoffRef.current = 1000
-      }
-
-      ws.onmessage = (event) => {
-        try {
-          const envelope = JSON.parse(event.data)
-          if (envelope.topic !== 'drone.detections') return
-          const msg = envelope.message
-          if (!Array.isArray(msg?.detections)) return
-
-          const now = Date.now()
-          const incoming = msg.detections.map((detection) => ({
-            detection,
-            arrivedAt: now,
-          }))
-
-          // Refresh timestamps for existing IDs; append new ones
-          detectionsRef.current = [
-            ...detectionsRef.current.filter(
-              (e) => !incoming.some((n) => n.detection.id === e.detection.id)
-            ),
-            ...incoming,
-          ]
-        } catch {
-          // Malformed frame — skip
-        }
-      }
-
-      ws.onclose = () => {
-        reconnectRef.current = setTimeout(connect, backoffRef.current)
-        backoffRef.current = Math.min(backoffRef.current * 2, 30000)
-      }
-
-      ws.onerror = () => {}
-    }
-
-    connect()
-
-    return () => {
-      clearTimeout(reconnectRef.current)
-      if (wsRef.current) {
-        wsRef.current.onclose = null
-        wsRef.current.close()
-      }
-    }
-  }, [])
+    // Refresh timestamps for existing IDs; append new ones
+    detectionsRef.current = [
+      ...detectionsRef.current.filter(
+        (e) => !incoming.some((n) => n.detection.id === e.detection.id)
+      ),
+      ...incoming,
+    ]
+  }, [data])
 
   // Animation loop
   useEffect(() => {

--- a/frontend/src/components/TacticalMap.jsx
+++ b/frontend/src/components/TacticalMap.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react'
-
-const WS_URL = 'ws://127.0.0.1:8000/events'
+import { useWebSocket } from '../contexts/WebSocketContext'
 
 const SRC_W = 960
 const SRC_H = 720
@@ -55,10 +54,10 @@ export default function TacticalMap() {
   const hoveredRef = useRef(null)
   const dirtyRef = useRef(true)
   const rafRef = useRef(null)
-  const wsRef = useRef(null)
-  const backoffRef = useRef(1000)
-  const reconnectRef = useRef(null)
   const prevTelemetryRef = useRef(null)
+
+  const { data: detectionsData } = useWebSocket('drone.detections')
+  const { data: telemetryData } = useWebSocket('drone.telemetry')
 
   const render = useCallback(() => {
     rafRef.current = requestAnimationFrame(render)
@@ -224,100 +223,61 @@ export default function TacticalMap() {
     }
   }, [])
 
-  // WebSocket
+  // Handle detections from shared WebSocket context
   useEffect(() => {
-    let ws
+    const msg = detectionsData
+    if (!Array.isArray(msg?.detections)) return
 
-    function connect() {
-      ws = new WebSocket(WS_URL)
-      wsRef.current = ws
+    for (const det of msg.detections) {
+      const { id, category, label, confidence, bbox_2d, threat_level } = det
+      if (!bbox_2d) continue
 
-      ws.onopen = () => {
-        backoffRef.current = 1000
-      }
+      const cx = ((bbox_2d.x1 + bbox_2d.x2) / 2) / SRC_W
+      const cy = ((bbox_2d.y1 + bbox_2d.y2) / 2) / SRC_H
 
-      ws.onmessage = (event) => {
-        try {
-          const envelope = JSON.parse(event.data)
+      const existing = markersRef.current.findIndex(
+        (m) => m.category === category &&
+          Math.hypot(cx - m.x, cy - m.y) < DEDUP_THRESHOLD
+      )
 
-          if (envelope.topic === 'drone.detections') {
-            const msg = envelope.message
-            if (!Array.isArray(msg?.detections)) return
+      const marker = { id, x: cx, y: cy, category, label, confidence, threat_level }
 
-            for (const det of msg.detections) {
-              const { id, category, label, confidence, bbox_2d, threat_level } = det
-              if (!bbox_2d) continue
-
-              const cx = ((bbox_2d.x1 + bbox_2d.x2) / 2) / SRC_W
-              const cy = ((bbox_2d.y1 + bbox_2d.y2) / 2) / SRC_H
-
-              const existing = markersRef.current.findIndex(
-                (m) => m.category === category &&
-                  Math.hypot(cx - m.x, cy - m.y) < DEDUP_THRESHOLD
-              )
-
-              const marker = { id, x: cx, y: cy, category, label, confidence, threat_level }
-
-              if (existing >= 0) {
-                markersRef.current[existing] = marker
-              } else {
-                markersRef.current.push(marker)
-                if (markersRef.current.length > MAX_MARKERS) {
-                  markersRef.current.shift()
-                }
-              }
-            }
-
-            dirtyRef.current = true
-          }
-
-          if (envelope.topic === 'drone.telemetry') {
-            const msg = envelope.message
-            if (!msg) return
-
-            const prev = prevTelemetryRef.current
-            prevTelemetryRef.current = msg
-
-            // Use vx/vy if present, otherwise accumulate from speed + direction hints,
-            // otherwise fall back to null (pulsing center dot)
-            if (msg.x_cm !== undefined && msg.y_cm !== undefined) {
-              droneRef.current = {
-                x: Math.max(0, Math.min(1, msg.x_cm / SRC_W)),
-                y: Math.max(0, Math.min(1, msg.y_cm / SRC_H)),
-              }
-            } else if (prev && msg.vx !== undefined && msg.vy !== undefined) {
-              const cur = droneRef.current ?? { x: 0.5, y: 0.5 }
-              droneRef.current = {
-                x: Math.max(0, Math.min(1, cur.x + msg.vx * 0.01)),
-                y: Math.max(0, Math.min(1, cur.y + msg.vy * 0.01)),
-              }
-            }
-
-            dirtyRef.current = true
-          }
-        } catch {
-          // malformed — skip
+      if (existing >= 0) {
+        markersRef.current[existing] = marker
+      } else {
+        markersRef.current.push(marker)
+        if (markersRef.current.length > MAX_MARKERS) {
+          markersRef.current.shift()
         }
       }
-
-      ws.onclose = () => {
-        reconnectRef.current = setTimeout(connect, backoffRef.current)
-        backoffRef.current = Math.min(backoffRef.current * 2, 30000)
-      }
-
-      ws.onerror = () => {}
     }
 
-    connect()
+    dirtyRef.current = true
+  }, [detectionsData])
 
-    return () => {
-      clearTimeout(reconnectRef.current)
-      if (wsRef.current) {
-        wsRef.current.onclose = null
-        wsRef.current.close()
+  // Handle telemetry from shared WebSocket context
+  useEffect(() => {
+    const msg = telemetryData
+    if (!msg) return
+
+    const prev = prevTelemetryRef.current
+    prevTelemetryRef.current = msg
+
+    if (msg.x_cm !== undefined && msg.y_cm !== undefined) {
+      droneRef.current = {
+        x: Math.max(0, Math.min(1, msg.x_cm / SRC_W)),
+        y: Math.max(0, Math.min(1, msg.y_cm / SRC_H)),
+      }
+    } else if (prev && msg.vx !== undefined && msg.vy !== undefined) {
+      const cur = droneRef.current ?? { x: 0.5, y: 0.5 }
+      droneRef.current = {
+        x: Math.max(0, Math.min(1, cur.x + msg.vx * 0.01)),
+        y: Math.max(0, Math.min(1, cur.y + msg.vy * 0.01)),
       }
     }
-  }, [])
+
+    dirtyRef.current = true
+  }, [telemetryData])
 
   // Render loop
   useEffect(() => {

--- a/frontend/src/components/TelemetryHUD.jsx
+++ b/frontend/src/components/TelemetryHUD.jsx
@@ -1,22 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
+import { batteryColor, formatFlightTime } from '../lib/telemetry'
 
 const HEALTH_URL = '/api/health'
 const POLL_INTERVAL_MS = 2000
-
-function batteryColor(battery) {
-  if (battery === null || battery === undefined) return '#6b7280'
-  if (battery > 50) return '#22c55e'
-  if (battery >= 20) return '#eab308'
-  return '#ef4444'
-}
-
-export function formatFlightTime(seconds) {
-  if (seconds === null || seconds === undefined) return '--:--'
-  const m = Math.floor(seconds / 60).toString().padStart(2, '0')
-  const s = (seconds % 60).toString().padStart(2, '0')
-  return `${m}:${s}`
-}
 
 export default function TelemetryHUD() {
   const { data: wsData, connectionState } = useWebSocket('drone.telemetry')

--- a/frontend/src/components/TelemetryHUD.jsx
+++ b/frontend/src/components/TelemetryHUD.jsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
+import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
 
-const WS_URL = 'ws://127.0.0.1:8000/events'
 const HEALTH_URL = '/api/health'
 const POLL_INTERVAL_MS = 2000
-const RECONNECT_DELAY_MS = 1000
 
 function batteryColor(battery) {
   if (battery === null || battery === undefined) return '#6b7280'
@@ -12,7 +11,7 @@ function batteryColor(battery) {
   return '#ef4444'
 }
 
-function formatFlightTime(seconds) {
+export function formatFlightTime(seconds) {
   if (seconds === null || seconds === undefined) return '--:--'
   const m = Math.floor(seconds / 60).toString().padStart(2, '0')
   const s = (seconds % 60).toString().padStart(2, '0')
@@ -20,76 +19,46 @@ function formatFlightTime(seconds) {
 }
 
 export default function TelemetryHUD() {
-  const [telemetry, setTelemetry] = useState(null)
-  const [wsConnected, setWsConnected] = useState(false)
-  const wsRef = useRef(null)
+  const { data: wsData, connectionState } = useWebSocket('drone.telemetry')
+  const [polledTelemetry, setPolledTelemetry] = useState(null)
   const pollRef = useRef(null)
-  const reconnectRef = useRef(null)
 
-  function startPolling() {
+  // Fall back to polling when WS is not connected
+  useEffect(() => {
+    if (connectionState === CONNECTION_STATE.CONNECTED) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+      }
+      return
+    }
+
     if (pollRef.current) return
+
     pollRef.current = setInterval(async () => {
       try {
         const res = await fetch(HEALTH_URL)
         if (res.ok) {
           const data = await res.json()
-          if (data.telemetry) setTelemetry(data.telemetry)
+          if (data.telemetry) setPolledTelemetry(data.telemetry)
         }
       } catch {
         // server not yet up, keep trying
       }
     }, POLL_INTERVAL_MS)
-  }
 
-  function stopPolling() {
-    if (pollRef.current) {
-      clearInterval(pollRef.current)
-      pollRef.current = null
-    }
-  }
-
-  function connect() {
-    const ws = new WebSocket(WS_URL)
-    wsRef.current = ws
-
-    ws.onopen = () => {
-      setWsConnected(true)
-      stopPolling()
-    }
-
-    ws.onmessage = (evt) => {
-      try {
-        const msg = JSON.parse(evt.data)
-        if (msg.topic === 'drone.telemetry' && msg.message) {
-          setTelemetry(msg.message)
-        }
-      } catch {
-        // malformed message, ignore
-      }
-    }
-
-    ws.onclose = () => {
-      setWsConnected(false)
-      startPolling()
-      reconnectRef.current = setTimeout(connect, RECONNECT_DELAY_MS)
-    }
-
-    ws.onerror = () => {
-      ws.close()
-    }
-  }
-
-  useEffect(() => {
-    connect()
     return () => {
-      clearTimeout(reconnectRef.current)
-      stopPolling()
-      if (wsRef.current) {
-        wsRef.current.onclose = null
-        wsRef.current.close()
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
       }
     }
-  }, [])
+  }, [connectionState])
+
+  // Prefer live WS data; fall back to polled
+  const telemetry = wsData ?? polledTelemetry
+
+  const wsConnected = connectionState === CONNECTION_STATE.CONNECTED
 
   const bat = telemetry?.battery ?? null
   const alt = telemetry?.height_cm ?? null
@@ -102,7 +71,7 @@ export default function TelemetryHUD() {
       <div className="telemetry-hud__header">
         <span className="telemetry-hud__title">TELEMETRY HUD</span>
         <span className="telemetry-hud__ws" style={{ color: wsConnected ? '#22c55e' : '#6b7280' }}>
-          {wsConnected ? 'WS' : 'POLL'}
+          {wsConnected ? 'LIVE' : 'DELAYED'}
         </span>
       </div>
 

--- a/frontend/src/contexts/WebSocketContext.jsx
+++ b/frontend/src/contexts/WebSocketContext.jsx
@@ -1,0 +1,132 @@
+import { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react'
+
+const WS_URL = 'ws://127.0.0.1:8000/events'
+
+// Connection states
+export const CONNECTION_STATE = {
+  CONNECTED: 'connected',
+  RECONNECTING: 'reconnecting',
+  DISCONNECTED: 'disconnected',
+}
+
+const WebSocketContext = createContext(null)
+
+/**
+ * Provides a single shared WebSocket connection to all children.
+ * Components subscribe by topic; only messages matching their topic are
+ * delivered to their callbacks.
+ */
+export function WebSocketProvider({ children }) {
+  const [connectionState, setConnectionState] = useState(CONNECTION_STATE.DISCONNECTED)
+  const wsRef = useRef(null)
+  const backoffRef = useRef(1000)
+  const reconnectTimerRef = useRef(null)
+  // Map of topic -> Set of listener callbacks
+  const listenersRef = useRef(new Map())
+  // Latest data per topic, so late-subscribing components get the last value
+  const latestRef = useRef(new Map())
+
+  const subscribe = useCallback((topic, callback) => {
+    if (!listenersRef.current.has(topic)) {
+      listenersRef.current.set(topic, new Set())
+    }
+    listenersRef.current.get(topic).add(callback)
+
+    // Deliver the latest cached value immediately if available
+    if (latestRef.current.has(topic)) {
+      callback(latestRef.current.get(topic))
+    }
+
+    return () => {
+      const set = listenersRef.current.get(topic)
+      if (set) {
+        set.delete(callback)
+        if (set.size === 0) listenersRef.current.delete(topic)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    function connect() {
+      const ws = new WebSocket(WS_URL)
+      wsRef.current = ws
+      setConnectionState(CONNECTION_STATE.RECONNECTING)
+
+      ws.onopen = () => {
+        backoffRef.current = 1000
+        setConnectionState(CONNECTION_STATE.CONNECTED)
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const envelope = JSON.parse(event.data)
+          const { topic, message } = envelope
+          if (!topic) return
+
+          latestRef.current.set(topic, message)
+
+          const callbacks = listenersRef.current.get(topic)
+          if (callbacks) {
+            for (const cb of callbacks) {
+              cb(message)
+            }
+          }
+        } catch {
+          // Malformed frame — skip
+        }
+      }
+
+      ws.onclose = () => {
+        setConnectionState(CONNECTION_STATE.RECONNECTING)
+        reconnectTimerRef.current = setTimeout(() => {
+          backoffRef.current = Math.min(backoffRef.current * 2, 30000)
+          connect()
+        }, backoffRef.current)
+      }
+
+      ws.onerror = () => {
+        // onclose fires after onerror; handled there
+      }
+    }
+
+    connect()
+
+    return () => {
+      clearTimeout(reconnectTimerRef.current)
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.close()
+      }
+      setConnectionState(CONNECTION_STATE.DISCONNECTED)
+    }
+  }, [])
+
+  return (
+    <WebSocketContext.Provider value={{ connectionState, subscribe }}>
+      {children}
+    </WebSocketContext.Provider>
+  )
+}
+
+/**
+ * Subscribe to a single WebSocket topic.
+ *
+ * @param {string} topic  e.g. "drone.telemetry", "drone.detections", "drone.position"
+ * @returns {{ data: any, connectionState: string }}
+ */
+export function useWebSocket(topic) {
+  const ctx = useContext(WebSocketContext)
+  if (!ctx) {
+    throw new Error('useWebSocket must be used inside <WebSocketProvider>')
+  }
+
+  const { connectionState, subscribe } = ctx
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    const unsub = subscribe(topic, setData)
+    return unsub
+  }, [topic, subscribe])
+
+  return { data, connectionState }
+}

--- a/frontend/src/contexts/WebSocketContext.jsx
+++ b/frontend/src/contexts/WebSocketContext.jsx
@@ -48,44 +48,55 @@ export function WebSocketProvider({ children }) {
 
   useEffect(() => {
     function connect() {
-      const ws = new WebSocket(WS_URL)
-      wsRef.current = ws
-      setConnectionState(CONNECTION_STATE.RECONNECTING)
+      try {
+        const ws = new WebSocket(WS_URL)
+        wsRef.current = ws
 
-      ws.onopen = () => {
-        backoffRef.current = 1000
-        setConnectionState(CONNECTION_STATE.CONNECTED)
-      }
-
-      ws.onmessage = (event) => {
-        try {
-          const envelope = JSON.parse(event.data)
-          const { topic, message } = envelope
-          if (!topic) return
-
-          latestRef.current.set(topic, message)
-
-          const callbacks = listenersRef.current.get(topic)
-          if (callbacks) {
-            for (const cb of callbacks) {
-              cb(message)
-            }
-          }
-        } catch {
-          // Malformed frame — skip
+        ws.onopen = () => {
+          backoffRef.current = 1000
+          setConnectionState(CONNECTION_STATE.CONNECTED)
         }
-      }
 
-      ws.onclose = () => {
+        ws.onmessage = (event) => {
+          try {
+            const envelope = JSON.parse(event.data)
+            const { topic, message } = envelope
+            if (!topic) return
+
+            latestRef.current.set(topic, message)
+
+            const callbacks = listenersRef.current.get(topic)
+            if (callbacks) {
+              for (const cb of callbacks) {
+                cb(message)
+              }
+            }
+          } catch {
+            // Malformed frame — skip
+          }
+        }
+
+        ws.onclose = () => {
+          // Clear cached data so stale values aren't served after reconnect
+          latestRef.current = new Map()
+          setConnectionState(CONNECTION_STATE.RECONNECTING)
+          reconnectTimerRef.current = setTimeout(() => {
+            backoffRef.current = Math.min(backoffRef.current * 2, 30000)
+            connect()
+          }, backoffRef.current)
+        }
+
+        ws.onerror = () => {
+          // onclose fires after onerror; handled there
+        }
+      } catch (err) {
+        console.error('WebSocket connection failed:', err)
         setConnectionState(CONNECTION_STATE.RECONNECTING)
+        // Schedule retry with backoff
         reconnectTimerRef.current = setTimeout(() => {
           backoffRef.current = Math.min(backoffRef.current * 2, 30000)
           connect()
         }, backoffRef.current)
-      }
-
-      ws.onerror = () => {
-        // onclose fires after onerror; handled there
       }
     }
 

--- a/frontend/src/lib/telemetry.js
+++ b/frontend/src/lib/telemetry.js
@@ -1,0 +1,18 @@
+/**
+ * Shared telemetry display utilities.
+ * Used by AppHeader and TelemetryHUD.
+ */
+
+export function batteryColor(level) {
+  if (level === null || level === undefined) return undefined
+  if (level > 50) return 'var(--color-status-normal)'
+  if (level >= 20) return 'var(--color-status-caution)'
+  return 'var(--color-status-critical)'
+}
+
+export function formatFlightTime(seconds) {
+  if (seconds === null || seconds === undefined) return '--:--'
+  const m = Math.floor(seconds / 60).toString().padStart(2, '0')
+  const s = (seconds % 60).toString().padStart(2, '0')
+  return `${m}:${s}`
+}


### PR DESCRIPTION
## Summary

Structural frontend redesign — three-zone layout replacing sidebar scroll model.

- Shared WebSocket context (single connection replaces 3 independent ones)
- Three-zone layout: video (Zone A) + right panel 320px (Zone B) + bottom bar 32px (Zone C)
- Global header with compact telemetry chips (dissolves TelemetryHUD panel)
- Bottom status bar with system indicators
- Glassmorphism panel treatment

Closes #57, closes #58, closes #59, closes #60, closes #65

## Test Plan

- [ ] All telemetry data displays in header chips
- [ ] Tactical map fills right panel without scrolling
- [ ] Flight controls visible above tactical map
- [ ] Bottom bar shows connection + mode + POI count
- [ ] No content hidden below fold on 1920x1080
- [ ] Video feed + detection overlay still functional
- [ ] WebSocket reconnect works (stop/start backend)