### PR TITLE
feat: mission phases + Map3D promotion — link #64

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -598,6 +598,17 @@
   color: rgba(255, 255, 255, 0.72);
 }
 
+/* ── Mission phase badge ─────────────────────────────────── */
+
+@keyframes phase-badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.65; }
+}
+
+.phase-badge-active {
+  animation: phase-badge-pulse 2s ease-in-out infinite;
+}
+
 /* ── Responsive: 1920×1080 primary target ───────────────── */
 
 @media (min-width: 1600px) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -464,7 +464,6 @@
 
 .map3d {
   height: 100%;
-  min-height: 220px;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 import { WebSocketProvider } from './contexts/WebSocketContext'
+import { MissionPhaseProvider } from './contexts/MissionPhaseContext'
 import AppHeader from './components/AppHeader'
 import BottomBar from './components/BottomBar'
 import VideoPanel from './components/VideoPanel'
@@ -14,6 +15,7 @@ export default function App() {
 
   return (
     <WebSocketProvider>
+      <MissionPhaseProvider>
       {/* Full viewport column flex */}
       <div className="h-screen w-screen flex flex-col overflow-hidden bg-[var(--bg-base)]">
 
@@ -54,6 +56,7 @@ export default function App() {
         <BottomBar />
 
       </div>
+      </MissionPhaseProvider>
     </WebSocketProvider>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 import { WebSocketProvider } from './contexts/WebSocketContext'
-import { MissionPhaseProvider } from './contexts/MissionPhaseContext'
+import { MissionPhaseProvider, useMissionPhase, PHASE } from './contexts/MissionPhaseContext'
 import AppHeader from './components/AppHeader'
 import BottomBar from './components/BottomBar'
 import VideoPanel from './components/VideoPanel'
@@ -10,52 +10,156 @@ import TacticalMap from './components/TacticalMap'
 import Map3D from './components/Map3D'
 import './App.css'
 
-export default function App() {
+function PreFlightStatus() {
+  return (
+    <div
+      className="glass-panel flex flex-col items-center justify-center gap-3 p-5 flex-shrink-0"
+      style={{ borderColor: 'var(--color-status-standby, rgba(96,165,250,0.3))' }}
+    >
+      <span
+        className="font-mono text-[11px] font-semibold tracking-[0.14em] uppercase"
+        style={{ color: 'var(--color-status-standby, #60a5fa)' }}
+      >
+        PREFLIGHT
+      </span>
+      <span
+        className="font-mono text-[10px] tracking-[0.1em] uppercase"
+        style={{ color: 'rgba(255,255,255,0.45)' }}
+      >
+        Waiting for launch
+      </span>
+    </div>
+  )
+}
+
+function PostFlightActions({ flightTime, poiCount }) {
+  return (
+    <div
+      className="glass-panel flex flex-col gap-3 p-4 flex-shrink-0"
+    >
+      <span
+        className="font-mono text-[11px] font-semibold tracking-[0.14em] uppercase"
+        style={{ color: 'var(--color-accent-blue)' }}
+      >
+        MISSION COMPLETE
+      </span>
+
+      {/* Summary row */}
+      <div className="flex gap-4">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[9px] tracking-[0.1em] uppercase" style={{ color: 'rgba(255,255,255,0.4)' }}>
+            FLIGHT TIME
+          </span>
+          <span className="font-mono text-[12px] font-semibold" style={{ color: 'rgba(255,255,255,0.85)' }}>
+            {flightTime ?? '--:--'}
+          </span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[9px] tracking-[0.1em] uppercase" style={{ color: 'rgba(255,255,255,0.4)' }}>
+            TOTAL POI
+          </span>
+          <span className="font-mono text-[12px] font-semibold" style={{ color: 'rgba(255,255,255,0.85)' }}>
+            {poiCount ?? 0}
+          </span>
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className="flex-1 py-2 rounded font-mono text-[11px] font-extrabold tracking-[0.12em] uppercase"
+          style={{
+            border: '1px solid var(--color-accent-blue)',
+            background: 'transparent',
+            color: 'var(--color-accent-blue)',
+            cursor: 'pointer',
+          }}
+        >
+          VIEW REPLAY
+        </button>
+        <button
+          type="button"
+          className="flex-1 py-2 rounded font-mono text-[11px] font-extrabold tracking-[0.12em] uppercase"
+          style={{
+            border: '1px solid var(--color-accent-blue)',
+            background: 'transparent',
+            color: 'var(--color-accent-blue)',
+            cursor: 'pointer',
+          }}
+        >
+          EXPORT REPORT
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function AppLayout() {
   const videoFrameRef = useRef(null)
+  const { phase } = useMissionPhase()
 
   return (
-    <WebSocketProvider>
-      <MissionPhaseProvider>
-      {/* Full viewport column flex */}
-      <div className="h-screen w-screen flex flex-col overflow-hidden bg-[var(--bg-base)]">
+    <div className="h-screen w-screen flex flex-col overflow-hidden bg-[var(--bg-base)]">
 
-        {/* Header — 48px fixed */}
-        <AppHeader />
+      {/* Header — 48px fixed */}
+      <AppHeader />
 
-        {/* Main — flex row, fills remaining height between header and bottom bar */}
-        <main className="flex-1 flex flex-row overflow-hidden">
+      {/* Main — flex row, fills remaining height between header and bottom bar */}
+      <main className="flex-1 flex flex-row overflow-hidden">
 
-          {/* Zone A — video + detection overlay, left column */}
-          <section className="flex-1 min-w-0 p-4">
+        {/* Zone A — primary view, left column */}
+        <section className="flex-1 min-w-0 p-4">
+          {phase === PHASE.POST_FLIGHT ? (
+            <div className="h-full glass-panel overflow-hidden">
+              <Map3D />
+            </div>
+          ) : (
             <div className="video-overlay-container h-full">
               <VideoPanel frameRef={videoFrameRef} />
               <DetectionOverlay containerRef={videoFrameRef} />
             </div>
-          </section>
+          )}
+        </section>
 
-          {/* Zone B — right sidebar: controls (fixed) + tactical map (flex) */}
-          <aside className="w-[320px] flex flex-col flex-shrink-0 p-4 pl-0 gap-3">
-            {/* Flight controls — fixed height content */}
+        {/* Zone B — right sidebar */}
+        <aside className="w-[320px] flex flex-col flex-shrink-0 p-4 pl-0 gap-3">
+
+          {/* Flight controls or phase card */}
+          {phase === PHASE.ACTIVE && (
             <div className="flex-shrink-0 glass-panel overflow-hidden">
               <FlightControls />
             </div>
+          )}
+          {phase === PHASE.PRE_FLIGHT && <PreFlightStatus />}
+          {phase === PHASE.POST_FLIGHT && <PostFlightActions />}
 
-            {/* Tactical Map — flex-1 fills remaining space */}
-            <div className="flex-1 min-h-0 glass-panel overflow-hidden">
-              <TacticalMap />
-            </div>
+          {/* Tactical Map — always visible */}
+          <div className="flex-1 min-h-0 glass-panel overflow-hidden">
+            <TacticalMap />
+          </div>
 
-            {/* 3D Map */}
+          {/* 3D Map — only in ACTIVE phase (sidebar position) */}
+          {phase === PHASE.ACTIVE && (
             <div className="flex-1 min-h-0 glass-panel overflow-hidden">
               <Map3D />
             </div>
-          </aside>
-        </main>
+          )}
+        </aside>
+      </main>
 
-        {/* Zone C — bottom bar, 32px fixed */}
-        <BottomBar />
+      {/* Zone C — bottom bar, 32px fixed */}
+      <BottomBar phase={phase} />
 
-      </div>
+    </div>
+  )
+}
+
+export default function App() {
+  return (
+    <WebSocketProvider>
+      <MissionPhaseProvider>
+        <AppLayout />
       </MissionPhaseProvider>
     </WebSocketProvider>
   )

--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -1,4 +1,5 @@
 import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
+import { useMissionPhase, PHASE } from '../contexts/MissionPhaseContext'
 import { batteryColor, formatFlightTime } from '../lib/telemetry'
 
 function TelemetryChip({ label, value, valueStyle }) {
@@ -20,6 +21,50 @@ function TelemetryChip({ label, value, valueStyle }) {
   )
 }
 
+const PHASE_LABEL = {
+  [PHASE.PRE_FLIGHT]: 'PRE-FLIGHT',
+  [PHASE.ACTIVE]: 'ACTIVE',
+  [PHASE.POST_FLIGHT]: 'POST-FLIGHT',
+}
+
+function phaseBadgeColor(phase) {
+  switch (phase) {
+    case PHASE.ACTIVE:
+      return 'var(--color-status-normal)'
+    case PHASE.POST_FLIGHT:
+      return 'var(--color-text-secondary)'
+    default:
+      return 'var(--color-status-standby)'
+  }
+}
+
+function PhaseBadge({ phase }) {
+  const color = phaseBadgeColor(phase)
+  const isActive = phase === PHASE.ACTIVE
+
+  return (
+    <span
+      className={isActive ? 'phase-badge-active' : undefined}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 8px',
+        borderRadius: '9999px',
+        border: `1px solid ${color}`,
+        background: `color-mix(in oklch, ${color} 12%, transparent)`,
+        color,
+        fontFamily: 'var(--font-mono)',
+        fontSize: '10px',
+        fontWeight: 400,
+        letterSpacing: '0.1em',
+        textTransform: 'uppercase',
+      }}
+    >
+      {PHASE_LABEL[phase]}
+    </span>
+  )
+}
+
 function statusDotColor(connectionState) {
   switch (connectionState) {
     case CONNECTION_STATE.CONNECTED:
@@ -33,6 +78,7 @@ function statusDotColor(connectionState) {
 
 export default function AppHeader() {
   const { data: telemetry, connectionState } = useWebSocket('drone.telemetry')
+  const { phase } = useMissionPhase()
 
   const bat = telemetry?.battery ?? null
   const alt = telemetry?.height_cm ?? null
@@ -72,6 +118,9 @@ export default function AppHeader() {
           Autonomous Indoor Mapping · NatSec 2026
         </span>
       </div>
+
+      {/* Center: mission phase badge */}
+      <PhaseBadge phase={phase} />
 
       {/* Right: telemetry chips + connection dot */}
       <div className="flex items-center gap-2">

--- a/frontend/src/components/BottomBar.jsx
+++ b/frontend/src/components/BottomBar.jsx
@@ -1,4 +1,5 @@
 import { useWebSocket, CONNECTION_STATE } from '../contexts/WebSocketContext'
+import { PHASE } from '../contexts/MissionPhaseContext'
 
 function Separator() {
   return (
@@ -77,7 +78,7 @@ function wsHealthLabel(connectionState) {
   }
 }
 
-export default function BottomBar() {
+export default function BottomBar({ phase }) {
   const { data: telemetry, connectionState } = useWebSocket('drone.telemetry')
   const { data: detectionsData } = useWebSocket('drone.detections')
 
@@ -131,20 +132,22 @@ export default function BottomBar() {
         />
       </div>
 
-      {/* Right: 3D toggle placeholder */}
-      <button
-        type="button"
-        disabled
-        className="flex items-center gap-1.5 px-2 py-0.5 rounded border opacity-40 cursor-not-allowed"
-        title="3D view coming soon"
-        style={{
-          borderColor: 'var(--color-border-default)',
-          background: 'transparent',
-          color: 'var(--color-text-secondary)',
-        }}
-      >
-        <span className="font-mono text-[11px] font-medium">[3D]</span>
-      </button>
+      {/* Right: 3D toggle — hidden in POST_FLIGHT (3D already primary) and PRE_FLIGHT */}
+      {phase === PHASE.ACTIVE && (
+        <button
+          type="button"
+          disabled
+          className="flex items-center gap-1.5 px-2 py-0.5 rounded border opacity-40 cursor-not-allowed"
+          title="3D view coming soon"
+          style={{
+            borderColor: 'var(--color-border-default)',
+            background: 'transparent',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          <span className="font-mono text-[11px] font-medium">[3D]</span>
+        </button>
+      )}
     </footer>
   )
 }

--- a/frontend/src/components/BottomBar.jsx
+++ b/frontend/src/components/BottomBar.jsx
@@ -18,7 +18,7 @@ function StatusItem({ label, value, valueStyle }) {
   return (
     <div className="flex items-center gap-1.5">
       <span
-        className="font-ui text-[11px] uppercase tracking-[0.12em]"
+        className="font-sans text-[10px] uppercase tracking-[0.12em]"
         style={{ color: 'var(--color-text-subtle)' }}
       >
         {label}
@@ -37,14 +37,14 @@ function StatusDotItem({ label, dotColor, text, textColor }) {
   return (
     <div className="flex items-center gap-1.5">
       <span
-        className="font-ui text-[11px] uppercase tracking-[0.12em]"
+        className="font-sans text-[10px] uppercase tracking-[0.12em]"
         style={{ color: 'var(--color-text-subtle)' }}
       >
         {label}
       </span>
       <span
         className="inline-block rounded-full flex-shrink-0"
-        style={{ width: '7px', height: '7px', background: dotColor }}
+        style={{ width: '6px', height: '6px', background: dotColor }}
       />
       <span
         className="font-mono text-[11px]"

--- a/frontend/src/components/Map3D.jsx
+++ b/frontend/src/components/Map3D.jsx
@@ -51,6 +51,7 @@ export default function Map3D() {
   const rootRef = useRef(null)
   const pointsRef = useRef(null)
   const rendererRef = useRef(null)
+  const controlsRef = useRef(null)
   const labelRef = useRef(null)
   const threeRef = useRef(null)
   const [depthSrc, setDepthSrc] = useState(null)
@@ -66,8 +67,12 @@ export default function Map3D() {
     let material
     let grid
     let axes
+    let controls
 
-    import('three').then((THREE) => {
+    Promise.all([
+      import('three'),
+      import('three/examples/jsm/controls/OrbitControls.js'),
+    ]).then(([THREE, { OrbitControls }]) => {
       if (!running) return
       threeRef.current = THREE
 
@@ -82,6 +87,11 @@ export default function Map3D() {
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
       rendererRef.current = renderer
       root.appendChild(renderer.domElement)
+
+      controls = new OrbitControls(camera, renderer.domElement)
+      controls.enableDamping = true
+      controls.dampingFactor = 0.05
+      controlsRef.current = controls
 
       grid = new THREE.GridHelper(1.6, 12, 0x2dd4bf, 0x1f2937)
       grid.rotation.x = Math.PI / 2
@@ -113,9 +123,7 @@ export default function Map3D() {
 
       const render = () => {
         if (!running) return
-        if (pointsRef.current) {
-          pointsRef.current.rotation.y += 0.003
-        }
+        controls.update()
         renderer.render(scene, camera)
         requestAnimationFrame(render)
       }
@@ -125,6 +133,7 @@ export default function Map3D() {
     return () => {
       running = false
       ro?.disconnect()
+      controlsRef.current?.dispose()
       renderer?.dispose()
       material?.dispose()
       grid?.geometry.dispose()
@@ -150,11 +159,12 @@ export default function Map3D() {
         pointsRef.current.geometry = next
         prev.dispose()
         if (labelRef.current) {
-          labelRef.current.textContent = `${cloud.source || 'point_cloud'} · ${cloud.points?.length ?? 0} pts`
+          const count = cloud.points?.length ?? 0
+          labelRef.current.textContent = `3D RECON · ${count.toLocaleString()} pts`
         }
       } catch {
         if (labelRef.current) {
-          labelRef.current.textContent = 'waiting for 3D reconstruction'
+          labelRef.current.textContent = '3D RECON · waiting for reconstruction'
         }
       }
     }
@@ -198,7 +208,7 @@ export default function Map3D() {
     <div className="map3d">
       <div className="map3d__header">
         <span className="map3d__title">3D RECON</span>
-        <span ref={labelRef} className="map3d__status">waiting for 3D reconstruction</span>
+        <span ref={labelRef} className="map3d__status">3D RECON · waiting for reconstruction</span>
       </div>
       <div className="map3d__body">
         <div ref={rootRef} className="map3d__viewport" />

--- a/frontend/src/components/TacticalMap.jsx
+++ b/frontend/src/components/TacticalMap.jsx
@@ -48,48 +48,57 @@ function drawGrid(ctx, w, h) {
 }
 
 function drawLegend(ctx, h) {
-  const PAD = 8
-  const DOT_R = 4
-  const LINE_H = 16
-  const FONT_SIZE = 10
-  const entries = Object.entries(CATEGORY_COLORS)
+  const PAD = 6
+  const DOT_R = 2
+  const FONT_SIZE = 9
+  const LINE_H = 13
+  const COL_GAP = 8
+  const MAX_ENTRIES = 5
+
+  const entries = Object.entries(CATEGORY_COLORS).slice(0, MAX_ENTRIES)
+  const COLS = 2
+  const ROWS = Math.ceil(entries.length / COLS)
 
   ctx.save()
   ctx.font = `${FONT_SIZE}px monospace`
 
-  // Measure widest label to size the background rect
+  // Measure widest label per column
   let maxLabelW = 0
   for (const [cat] of entries) {
     const tw = ctx.measureText(cat).width
     if (tw > maxLabelW) maxLabelW = tw
   }
 
-  const rectW = PAD * 2 + DOT_R * 2 + 6 + maxLabelW
-  const rectH = PAD * 2 + entries.length * LINE_H
+  const cellW = DOT_R * 2 + 4 + maxLabelW
+  const rectW = PAD * 2 + cellW * COLS + COL_GAP * (COLS - 1)
+  const rectH = PAD * 2 + ROWS * LINE_H
 
   const rx = PAD
   const ry = h - rectH - PAD
 
-  // Background
-  ctx.fillStyle = 'rgba(10, 10, 15, 0.72)'
+  // Background pill
+  ctx.fillStyle = 'rgba(10, 10, 15, 0.85)'
   ctx.beginPath()
-  ctx.roundRect(rx, ry, rectW, rectH, 3)
+  ctx.roundRect(rx, ry, rectW, rectH, 4)
   ctx.fill()
 
-  // Entries
+  // Entries — 2-column grid
   for (let i = 0; i < entries.length; i++) {
     const [cat, color] = entries[i]
-    const cx = rx + PAD + DOT_R
-    const cy = ry + PAD + i * LINE_H + LINE_H / 2
+    const col = i % COLS
+    const row = Math.floor(i / COLS)
+
+    const cellX = rx + PAD + col * (cellW + COL_GAP)
+    const cy = ry + PAD + row * LINE_H + LINE_H / 2
 
     ctx.beginPath()
-    ctx.arc(cx, cy, DOT_R, 0, Math.PI * 2)
+    ctx.arc(cellX + DOT_R, cy, DOT_R, 0, Math.PI * 2)
     ctx.fillStyle = color
     ctx.fill()
 
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.7)'
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.65)'
     ctx.textBaseline = 'middle'
-    ctx.fillText(cat, cx + DOT_R + 6, cy)
+    ctx.fillText(cat, cellX + DOT_R * 2 + 4, cy)
   }
 
   ctx.restore()

--- a/frontend/src/contexts/MissionPhaseContext.jsx
+++ b/frontend/src/contexts/MissionPhaseContext.jsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { useWebSocket, CONNECTION_STATE } from './WebSocketContext'
+
+export const PHASE = {
+  PRE_FLIGHT: 'PRE_FLIGHT',
+  ACTIVE: 'ACTIVE',
+  POST_FLIGHT: 'POST_FLIGHT',
+}
+
+const MissionPhaseContext = createContext(null)
+
+export function MissionPhaseProvider({ children }) {
+  const { data: telemetry, connectionState } = useWebSocket('drone.telemetry')
+  const hasFlownRef = useRef(false)
+  const [phaseOverride, setPhaseOverride] = useState(null)
+
+  const isConnected = connectionState === CONNECTION_STATE.CONNECTED
+  const isFlying = !!(
+    telemetry && (telemetry.flying === true || (telemetry.height_cm ?? 0) > 0)
+  )
+
+  if (isFlying) {
+    hasFlownRef.current = true
+  }
+
+  // Reset latch when connection drops so a reconnect starts fresh
+  useEffect(() => {
+    if (!isConnected) {
+      hasFlownRef.current = false
+    }
+  }, [isConnected])
+
+  let derived
+  if (isFlying) {
+    derived = PHASE.ACTIVE
+  } else if (hasFlownRef.current) {
+    derived = PHASE.POST_FLIGHT
+  } else {
+    derived = PHASE.PRE_FLIGHT
+  }
+
+  const phase = phaseOverride ?? derived
+
+  return (
+    <MissionPhaseContext.Provider value={{ phase, setPhaseOverride }}>
+      {children}
+    </MissionPhaseContext.Provider>
+  )
+}
+
+export function useMissionPhase() {
+  const ctx = useContext(MissionPhaseContext)
+  if (!ctx) {
+    throw new Error('useMissionPhase must be used inside <MissionPhaseProvider>')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary

Wave 3: mission-phase state management and Map3D upgrade.

- MissionPhaseContext: PRE_FLIGHT / ACTIVE / POST_FLIGHT derived from telemetry
- Phase badge in header with color coding
- Phase-aware component visibility (different layout per mission state)
- Post-flight: Map3D promoted to primary Zone A view with orbit controls
- Map3D: OrbitControls (pan/zoom/orbit), point count display, no more auto-rotate
- Bottom bar separator fix, tactical map legend compacted
- Post-flight action placeholders (View Replay, Export Report)

Closes #63, closes #64

## Test Plan

- [ ] Phase badge shows in header: [PRE-FLIGHT] cyan, [ACTIVE] green, [POST-FLIGHT] gray
- [ ] PRE_FLIGHT: no flight controls, no Map3D in sidebar
- [ ] ACTIVE: flight controls visible, Map3D hidden (toggle via [3D])
- [ ] POST_FLIGHT: Map3D fills Zone A, flight controls replaced with replay/export buttons
- [ ] Map3D: mouse orbit/pan/zoom works, no auto-rotation
- [ ] Map3D: header shows point count
- [ ] Bottom bar: proper separators between status groups
- [ ] Tactical map legend: compact, not oversized
- [ ] Manual phase override works for testing