### PR TITLE
feat: add depth proximity obstacle alerts with per-zone scoring

### DIFF
--- a/src/breacheye/rafa/orchestrator.py
+++ b/src/breacheye/rafa/orchestrator.py
@@ -248,6 +248,13 @@ class RafaPipeline:
         await self._publish("detections", detection)
         if depth is not None:
             await self._publish("depth", depth)
+            try:
+                from breacheye.rafa.spatial_context import compute_obstacle_alert
+                alert = compute_obstacle_alert(depth, frame_meta.frame_id, self._min_forward_clearance_m)
+                if self._bus is not None:
+                    await self._bus.publish("drone.obstacle_alert", alert.model_dump())
+            except Exception:
+                pass  # non-critical — don't break pipeline
         await self._publish("navigation", navigation)
         timings["publish_ms"] = _elapsed_ms(stage_started_at)
         self.logger.event(

--- a/src/breacheye/rafa/orchestrator.py
+++ b/src/breacheye/rafa/orchestrator.py
@@ -56,8 +56,9 @@ class RafaPipelineConfig:
 
 
 class RafaPipeline:
-    def __init__(self, config: RafaPipelineConfig | None = None) -> None:
+    def __init__(self, config: RafaPipelineConfig | None = None, bus: object | None = None) -> None:
         self.config = config or RafaPipelineConfig()
+        self._bus = bus
         self._context = None
         self._receiver: ZmqFrameReceiver | None = None
         self._sockets: dict[str, object] = {}

--- a/src/breacheye/rafa/schemas.py
+++ b/src/breacheye/rafa/schemas.py
@@ -193,3 +193,12 @@ class HealthOutput(StrictModel):
     memory: MemoryStatus = Field(default_factory=MemoryStatus)
     errors: list[str] = Field(default_factory=list)
     timestamp: float = Field(default_factory=time)
+
+
+class ObstacleAlert(StrictModel):
+    frame_id: int = Field(ge=0)
+    timestamp: float = Field(default_factory=time)
+    nearest_obstacle_m: float = Field(ge=0.0, le=1.0)
+    zones: dict[str, float]
+    blocked: bool
+    threshold: float = Field(ge=0.0, le=1.0)

--- a/src/breacheye/rafa/spatial_context.py
+++ b/src/breacheye/rafa/spatial_context.py
@@ -11,6 +11,7 @@ from breacheye.rafa.schemas import (
     MapObject,
     MapPose,
     NavigationAction,
+    ObstacleAlert,
     SpatialNavigationContext,
 )
 
@@ -121,3 +122,39 @@ def _resolve_frontier_clearance(value: float | None) -> float:
         except (TypeError, ValueError):
             value = 0.45
     return max(0.0, min(10.0, value))
+
+
+def compute_obstacle_alert(
+    depth: DepthOutput,
+    frame_id: int,
+    threshold: float = 0.45,
+) -> ObstacleAlert:
+    """Compute per-zone proximity scores from depth output."""
+    import numpy as np
+
+    values = np.frombuffer(depth.depth_bytes, dtype=np.float32).reshape(depth.shape)
+    height, width = values.shape
+
+    # Split into left/center/right thirds (column-wise)
+    left_zone = values[:, : width // 3]
+    center_zone = values[:, width // 3 : (width * 2) // 3]
+    right_zone = values[:, (width * 2) // 3 :]
+
+    zones = {}
+    for name, zone in [("left", left_zone), ("center", center_zone), ("right", right_zone)]:
+        finite = zone[np.isfinite(zone)]
+        if finite.size:
+            zones[name] = float(np.nanpercentile(finite, 20))
+        else:
+            zones[name] = 1.0  # no data = assume clear
+
+    nearest = min(zones.values())
+    blocked = any(v < threshold for v in zones.values())
+
+    return ObstacleAlert(
+        frame_id=frame_id,
+        nearest_obstacle_m=nearest,
+        zones=zones,
+        blocked=blocked,
+        threshold=threshold,
+    )

--- a/tests/test_obstacle_alert.py
+++ b/tests/test_obstacle_alert.py
@@ -1,0 +1,76 @@
+import numpy as np
+import pytest
+from breacheye.rafa.schemas import DepthOutput, ObstacleAlert
+from breacheye.rafa.spatial_context import compute_obstacle_alert
+
+
+def _make_depth(values: np.ndarray) -> DepthOutput:
+    """Create a DepthOutput from a numpy array."""
+    h, w = values.shape
+    return DepthOutput(
+        frame_id=0,
+        timestamp=1.0,
+        shape=(h, w),
+        depth_bytes=values.astype(np.float32).tobytes(),
+    )
+
+
+def test_uniform_clear_depth():
+    """All zones far away — not blocked."""
+    values = np.full((720, 960), 0.8, dtype=np.float32)
+    alert = compute_obstacle_alert(_make_depth(values), frame_id=1, threshold=0.45)
+    assert not alert.blocked
+    assert alert.nearest_obstacle_m > 0.45
+    assert "left" in alert.zones
+    assert "center" in alert.zones
+    assert "right" in alert.zones
+
+
+def test_center_blocked():
+    """Center zone has near obstacle — blocked."""
+    values = np.full((720, 960), 0.8, dtype=np.float32)
+    # Set center third to near
+    values[:, 320:640] = 0.1
+    alert = compute_obstacle_alert(_make_depth(values), frame_id=2, threshold=0.45)
+    assert alert.blocked
+    assert alert.zones["center"] < 0.45
+    assert alert.zones["left"] > 0.45
+    assert alert.zones["right"] > 0.45
+
+
+def test_left_blocked():
+    """Left zone blocked, others clear."""
+    values = np.full((720, 960), 0.8, dtype=np.float32)
+    values[:, :320] = 0.2
+    alert = compute_obstacle_alert(_make_depth(values), frame_id=3, threshold=0.45)
+    assert alert.blocked
+    assert alert.zones["left"] < 0.45
+    assert alert.zones["center"] > 0.45
+
+
+def test_all_clear_high_threshold():
+    """With a very high threshold, even moderate depth triggers blocked."""
+    values = np.full((720, 960), 0.5, dtype=np.float32)
+    alert = compute_obstacle_alert(_make_depth(values), frame_id=4, threshold=0.9)
+    assert alert.blocked
+
+
+def test_obstacle_alert_schema_validation():
+    """Verify ObstacleAlert validates correctly."""
+    alert = ObstacleAlert(
+        frame_id=0,
+        nearest_obstacle_m=0.3,
+        zones={"left": 0.6, "center": 0.3, "right": 0.8},
+        blocked=True,
+        threshold=0.45,
+    )
+    assert alert.blocked
+    assert alert.zones["center"] == 0.3
+
+
+def test_nearest_is_min_of_zones():
+    """nearest_obstacle_m should be the minimum zone score."""
+    values = np.full((720, 960), 0.8, dtype=np.float32)
+    values[:, :320] = 0.3  # left near
+    alert = compute_obstacle_alert(_make_depth(values), frame_id=5, threshold=0.45)
+    assert abs(alert.nearest_obstacle_m - min(alert.zones.values())) < 0.01


### PR DESCRIPTION
## Summary
- `ObstacleAlert` Pydantic schema in `schemas.py` — frame_id, nearest_obstacle_m, per-zone scores (left/center/right), blocked flag, threshold
- `compute_obstacle_alert()` in `spatial_context.py` — splits depth frame into column-wise thirds, 20th percentile per zone (conservative), blocked if any zone < threshold
- Orchestrator emits alert on `drone.obstacle_alert` bus topic after each depth estimation — non-critical, wrapped in try/except
- `RafaPipeline` now accepts optional `bus` parameter for event publishing
- 6 unit tests covering clear/blocked/threshold scenarios

Closes #72.

## Test plan
- [x] `pytest tests/test_obstacle_alert.py tests/test_spatial_context.py -v` — 11/11 passed
- [ ] Verify existing rafa orchestrator tests still pass
- [ ] Wire bus from HarnessRuntime when constructing RafaPipeline (separate ticket)