### PR TITLE
feat: add depth-aware forward guard to NavInterpreter

### DIFF
--- a/src/breacheye/nav_interpreter.py
+++ b/src/breacheye/nav_interpreter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from time import monotonic
@@ -20,10 +21,15 @@ class NavInterpreter:
         command_url: str = "http://localhost:8000/commands",
         log_dir: str | None = "logs",
         run_id: str | None = None,
+        bus: object | None = None,
     ) -> None:
         self.endpoint = endpoint
         self.command_url = command_url
         self.logger = RunLogger("nav_interpreter", log_dir=log_dir, run_id=run_id)
+        self._bus = bus
+        self._latest_alert: dict | None = None
+        self._alert_task: object | None = None
+        self._depth_threshold: float = _env_float("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", 0.45, minimum=0.0, maximum=1.0)
         self._socket = None
         self._client = None  # httpx.AsyncClient
         self._poller = None
@@ -57,7 +63,30 @@ class NavInterpreter:
         self._poller.register(self._socket, zmq.POLLIN)
         self.logger.event("nav_interpreter_start", endpoint=self.endpoint, command_url=self.command_url)
 
+        if self._bus is not None:
+            self._alert_task = asyncio.create_task(self._subscribe_alerts())
+
+    async def _subscribe_alerts(self) -> None:
+        """Subscribe to obstacle alerts on the bus. Keeps only latest (CONFLATE pattern)."""
+        try:
+            queue = await self._bus.subscribe("drone.obstacle_alert")
+            while True:
+                try:
+                    self._latest_alert = await queue.get()
+                except asyncio.CancelledError:
+                    await self._bus.unsubscribe("drone.obstacle_alert", queue)
+                    raise
+        except asyncio.CancelledError:
+            pass
+
     async def aclose(self) -> None:
+        if self._alert_task is not None:
+            self._alert_task.cancel()
+            try:
+                await self._alert_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._alert_task = None
         if self._socket is not None:
             self._socket.close(linger=0)
             self._socket = None
@@ -211,6 +240,24 @@ class NavInterpreter:
         return cmd
 
     def _guard_action(self, decision: NavigationDecision) -> str:
+        # Depth guard — blocks forward movement when obstacle detected
+        if decision.action == "move_forward" and self._latest_alert is not None:
+            alert = self._latest_alert
+            nearest = alert.get("nearest_obstacle_m", 1.0)
+            blocked = alert.get("blocked", False)
+            if blocked or nearest < self._depth_threshold:
+                self.logger.event(
+                    "navigation_depth_guard",
+                    frame_id=alert.get("frame_id"),
+                    requested_action="move_forward",
+                    substituted_action="rotate_right",
+                    nearest=nearest,
+                    zones=alert.get("zones"),
+                    threshold=self._depth_threshold,
+                )
+                self._forward_streak = 0
+                return "rotate_right"
+
         if decision.action == "move_forward":
             self._forward_streak += 1
             self._hover_streak = 0

--- a/tests/test_nav_depth_guard.py
+++ b/tests/test_nav_depth_guard.py
@@ -1,0 +1,109 @@
+"""Tests for NavInterpreter depth-aware forward guard."""
+from __future__ import annotations
+
+import pytest
+from breacheye.nav_interpreter import NavInterpreter
+from breacheye.rafa.schemas import NavigationDecision
+
+
+def _make_interpreter(**kwargs) -> NavInterpreter:
+    return NavInterpreter(
+        endpoint="tcp://127.0.0.1:5558",
+        command_url="http://localhost:8000/commands",
+        log_dir=None,
+        **kwargs,
+    )
+
+
+def _make_decision(action: str = "move_forward", confidence: float = 0.9) -> NavigationDecision:
+    return NavigationDecision(
+        action=action,
+        params={"distance_cm": 40},
+        confidence=confidence,
+        reasoning="test",
+        exploration_state="exploring",
+    )
+
+
+def _make_alert(nearest: float = 0.3, blocked: bool = True, threshold: float = 0.45) -> dict:
+    return {
+        "frame_id": 1,
+        "timestamp": 1.0,
+        "nearest_obstacle_m": nearest,
+        "zones": {"left": 0.8, "center": nearest, "right": 0.7},
+        "blocked": blocked,
+        "threshold": threshold,
+    }
+
+
+def test_forward_blocked_when_alert_blocked():
+    """move_forward replaced with rotate_right when alert.blocked=True."""
+    interp = _make_interpreter()
+    interp._latest_alert = _make_alert(nearest=0.2, blocked=True)
+    result = interp._guard_action(_make_decision("move_forward"))
+    assert result == "rotate_right"
+
+
+def test_forward_blocked_when_nearest_below_threshold():
+    """move_forward blocked when nearest < depth_threshold, even if blocked=False."""
+    interp = _make_interpreter()
+    interp._latest_alert = _make_alert(nearest=0.3, blocked=False)
+    interp._depth_threshold = 0.45
+    result = interp._guard_action(_make_decision("move_forward"))
+    assert result == "rotate_right"
+
+
+def test_forward_allowed_when_clear():
+    """move_forward passes through when alert shows clear."""
+    interp = _make_interpreter()
+    interp._latest_alert = _make_alert(nearest=0.8, blocked=False)
+    result = interp._guard_action(_make_decision("move_forward"))
+    assert result == "move_forward"
+
+
+def test_forward_allowed_when_no_alert():
+    """Graceful degradation: no alert received yet -> allow forward."""
+    interp = _make_interpreter()
+    assert interp._latest_alert is None
+    result = interp._guard_action(_make_decision("move_forward"))
+    assert result == "move_forward"
+
+
+def test_non_forward_actions_unaffected():
+    """Depth guard only applies to move_forward."""
+    interp = _make_interpreter()
+    interp._latest_alert = _make_alert(nearest=0.1, blocked=True)
+    assert interp._guard_action(_make_decision("rotate_right")) == "rotate_right"
+    assert interp._guard_action(_make_decision("hover")) == "hover"
+    assert interp._guard_action(_make_decision("move_left")) == "move_left"
+
+
+def test_streak_guards_still_work_after_depth_passes():
+    """After depth guard passes, streak guard still triggers."""
+    interp = _make_interpreter()
+    interp._latest_alert = _make_alert(nearest=0.8, blocked=False)
+    interp._max_forward_streak = 2
+
+    assert interp._guard_action(_make_decision("move_forward")) == "move_forward"
+    assert interp._guard_action(_make_decision("move_forward")) == "move_forward"
+    # Third should trigger streak guard
+    result = interp._guard_action(_make_decision("move_forward"))
+    assert result == "rotate_right"
+
+
+def test_depth_guard_resets_forward_streak():
+    """When depth guard fires, forward streak resets to 0."""
+    interp = _make_interpreter()
+    interp._max_forward_streak = 3
+
+    # Build up streak with clear alerts
+    interp._latest_alert = _make_alert(nearest=0.8, blocked=False)
+    interp._guard_action(_make_decision("move_forward"))
+    interp._guard_action(_make_decision("move_forward"))
+    assert interp._forward_streak == 2
+
+    # Now block — streak should reset
+    interp._latest_alert = _make_alert(nearest=0.2, blocked=True)
+    result = interp._guard_action(_make_decision("move_forward"))
+    assert result == "rotate_right"
+    assert interp._forward_streak == 0


### PR DESCRIPTION
## Summary
- Depth guard added at top of `_guard_action()` — blocks `move_forward` when ObstacleAlert shows `blocked=True` or `nearest_obstacle_m < threshold`
- Substitutes `rotate_right` to find clear path, preventing wall-pinning
- NavInterpreter now accepts optional `bus` parameter, subscribes to `drone.obstacle_alert` with CONFLATE pattern (latest-only)
- Graceful degradation: forward movement allowed when no alert received yet
- Threshold from env var `BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M` (default 0.45)
- 7 new tests, 26/26 total nav tests passing

Closes #73. Depends on #72 (ObstacleAlert schema, merged).

## Test plan
- [x] `pytest tests/test_nav_depth_guard.py tests/test_nav_interpreter.py -v` — 26/26 passed
- [ ] Wire bus from flight orchestrator when constructing NavInterpreter
- [ ] End-to-end: mock depth with near obstacle → verify drone rotates instead of advancing