### PR TITLE
feat: depth alerts, post-flight building reports, calibration tooling — link #72 #78 #79 #80

### DIFF
--- a/src/breacheye/cli.py
+++ b/src/breacheye/cli.py
@@ -32,10 +32,16 @@ def main() -> None:
     offline.add_argument("--log-dir", default="logs")
     offline.add_argument("--run-id")
 
-    report = subparsers.add_parser("report", help="Build an HTML report for a logged run.")
-    report.add_argument("--run-id", default="latest", help="Run id to report, or latest.")
-    report.add_argument("--log-dir", default="logs")
-    report.add_argument("--output")
+    html_report = subparsers.add_parser("html-report", help="Build an HTML report for a logged run.")
+    html_report.add_argument("--run-id", default="latest", help="Run id to report, or latest.")
+    html_report.add_argument("--log-dir", default="logs")
+    html_report.add_argument("--output")
+
+    report = subparsers.add_parser("report", help="Fetch and display a post-flight building assessment report.")
+    report.add_argument("--run-id", default=None, help="Run ID to fetch (informational; the harness serves its current record).")
+    report.add_argument("--format", choices=["text", "json"], default="text", dest="output_format", help="Output format (default: text).")
+    report.add_argument("--narrative", action="store_true", help="Include Qwen-generated narrative summary.")
+    report.add_argument("--harness-url", default="http://127.0.0.1:8000", help="Base URL of the running harness.")
 
     monitor = subparsers.add_parser("monitor", help="Watch live harness health, frames, and run logs.")
     monitor.add_argument("--run-id", default="latest", help="Run id to watch, or latest.")
@@ -150,8 +156,18 @@ def main() -> None:
         raise SystemExit(asyncio.run(_smoke(args.mode)))
     elif args.command == "offline":
         _offline(args.offline_command, log_dir=args.log_dir, run_id=args.run_id)
-    elif args.command == "report":
+    elif args.command == "html-report":
         _report(run_id=args.run_id, log_dir=args.log_dir, output=args.output)
+    elif args.command == "report":
+        raise SystemExit(
+            asyncio.run(
+                _building_report(
+                    harness_url=args.harness_url,
+                    output_format=args.output_format,
+                    narrative=args.narrative,
+                )
+            )
+        )
     elif args.command == "monitor":
         raise SystemExit(
             _monitor(
@@ -352,6 +368,47 @@ def _offline(command: str, log_dir: str = "logs", run_id: str | None = None) -> 
     else:
         path = create_bundle(log_dir=log_dir, run_id=run_id)
     print(path)
+
+
+async def _building_report(
+    *,
+    harness_url: str,
+    output_format: str,
+    narrative: bool,
+) -> int:
+    """Fetch a BuildingReport from the harness and display it."""
+    import json as _json
+    import urllib.request
+    import urllib.error
+
+    from breacheye.report import BuildingReport
+    from breacheye.report_generator import ReportGenerator
+
+    url = harness_url.rstrip("/") + "/report"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            data = _json.loads(response.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        print(f"error: could not reach harness at {url}: {exc}", flush=True)
+        return 1
+
+    try:
+        report = BuildingReport.model_validate(data)
+    except Exception as exc:
+        print(f"error: invalid report payload from harness: {exc}", flush=True)
+        return 1
+
+    generator = ReportGenerator()
+
+    if narrative:
+        report.narrative = await generator.generate_narrative(report)
+
+    if output_format == "json":
+        print(report.model_dump_json(indent=2))
+    else:
+        print(generator.generate_text_report(report))
+
+    return 0
 
 
 def _report(run_id: str, log_dir: str = "logs", output: str | None = None) -> None:

--- a/src/breacheye/flight_record.py
+++ b/src/breacheye/flight_record.py
@@ -1,0 +1,241 @@
+"""Flight data accumulator for post-flight report generation.
+
+Subscribes to bus events during flight and builds a structured flight record.
+Runs alongside ExplorationTracker but serves a different purpose — preserving
+the full record for post-flight synthesis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from time import time
+
+from breacheye.bus import AsyncEventBus
+from breacheye.report import BuildingReport, FlightSummary, ThreatSummary
+
+log = logging.getLogger(__name__)
+
+_TOPICS = [
+    "drone.detections",
+    "drone.state_change",
+    "drone.telemetry",
+    "drone.nav_decision",
+]
+
+# State names that mark flight start/end
+_TAKEOFF_STATE = "takeoff"
+_LANDING_STATES = {"landing", "complete"}
+
+
+@dataclass
+class FlightRecord:
+    run_id: str
+    start_time: float | None = None
+    end_time: float | None = None
+    detections: list[dict] = field(default_factory=list)
+    poi_summary: dict[str, int] = field(default_factory=dict)
+    threat_summary: dict[str, int] = field(default_factory=dict)
+    state_transitions: list[tuple[float, str, str]] = field(default_factory=list)
+    frames_processed: int = 0
+    nav_decisions: int = 0
+    battery_start: int | None = None
+    battery_end: int | None = None
+
+
+class FlightDataAccumulator:
+    """Accumulates bus events during a flight for post-flight report generation."""
+
+    def __init__(self, bus: AsyncEventBus, run_id: str) -> None:
+        self._bus = bus
+        self._record = FlightRecord(run_id=run_id)
+        self._detection_ids: set[str] = set()
+        self._queues: dict[str, asyncio.Queue] = {}
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Subscribe to relevant bus topics and start listening."""
+        for topic in _TOPICS:
+            self._queues[topic] = await self._bus.subscribe(topic)
+        self._task = asyncio.create_task(self._process_loop(), name="flight-data-accumulator")
+
+    async def stop(self) -> None:
+        """Unsubscribe from all topics and finalize the record."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        for topic, queue in self._queues.items():
+            await self._bus.unsubscribe(topic, queue)
+        self._queues.clear()
+
+    def get_record(self) -> FlightRecord:
+        """Return the accumulated flight record."""
+        return self._record
+
+    def to_building_report(self) -> BuildingReport:
+        """Convert the accumulated record to BuildingReport schema.
+
+        Deterministic conversion — no VLM needed. The narrative comes in #79.
+        """
+        rec = self._record
+        now = time()
+        start = rec.start_time or now
+        end = rec.end_time or now
+        duration = max(0.0, end - start)
+
+        flight = FlightSummary(
+            run_id=rec.run_id,
+            start_time=start,
+            end_time=end,
+            duration_s=duration,
+            frames_processed=rec.frames_processed,
+            detections_total=len(rec.detections),
+            nav_decisions_total=rec.nav_decisions,
+            battery_start=rec.battery_start,
+            battery_end=rec.battery_end,
+        )
+
+        # Build high-priority items from HOT detections
+        high_priority = [
+            d for d in rec.detections
+            if d.get("threat_level") in ("HOT", "WARM")
+        ]
+
+        threats = ThreatSummary(
+            total_pois=len(rec.detections),
+            by_category=dict(rec.poi_summary),
+            by_threat_level=dict(rec.threat_summary),
+            high_priority_items=high_priority,
+        )
+
+        return BuildingReport(
+            report_id=str(uuid.uuid4()),
+            generated_at=now,
+            flight=flight,
+            rooms=[],
+            threats=threats,
+            narrative="",
+        )
+
+    async def _process_loop(self) -> None:
+        """Multiplex all topic queues into a single processing loop."""
+        pending: set[asyncio.Task] = set()
+        # Build initial set of waiter tasks, keyed by topic name
+        topic_tasks: dict[asyncio.Task, str] = {}
+        for topic, queue in self._queues.items():
+            t = asyncio.create_task(queue.get(), name=topic)
+            pending.add(t)
+            topic_tasks[t] = topic
+
+        try:
+            while True:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                for t in done:
+                    topic = topic_tasks.pop(t)
+                    try:
+                        message = t.result()
+                        await self._dispatch(topic, message)
+                    except Exception as exc:
+                        log.warning("flight accumulator error on %s: %s", topic, exc)
+                    # Re-arm the waiter for this topic
+                    new_t = asyncio.create_task(self._queues[topic].get(), name=topic)
+                    pending.add(new_t)
+                    topic_tasks[new_t] = topic
+        except asyncio.CancelledError:
+            # Cancel all pending waiters before propagating
+            for t in pending:
+                t.cancel()
+            raise
+
+    async def _dispatch(self, topic: str, message: object) -> None:
+        if topic == "drone.detections":
+            self._handle_detections(message)
+        elif topic == "drone.state_change":
+            self._handle_state_change(message)
+        elif topic == "drone.telemetry":
+            self._handle_telemetry(message)
+        elif topic == "drone.nav_decision":
+            self._handle_nav_decision(message)
+
+    def _handle_detections(self, message: object) -> None:
+        """Extract detections from payload, deduplicate by id, count POIs and threats."""
+        if isinstance(message, dict):
+            raw_detections = message.get("detections", [])
+        elif hasattr(message, "detections"):
+            raw_detections = message.detections  # type: ignore[union-attr]
+        else:
+            return
+
+        # Count frames processed (one DetectionOutput per frame)
+        self._record.frames_processed += 1
+
+        for det in raw_detections:
+            if isinstance(det, dict):
+                det_id = det.get("id", "")
+                category = det.get("category", "")
+                threat = det.get("threat_level", "")
+            elif hasattr(det, "id"):
+                # Handle Pydantic model objects
+                det_id = det.id  # type: ignore[union-attr]
+                category = str(det.category) if hasattr(det, "category") else ""  # type: ignore[union-attr]
+                threat = str(det.threat_level) if hasattr(det, "threat_level") else ""  # type: ignore[union-attr]
+                det = det.model_dump() if hasattr(det, "model_dump") else {}
+            else:
+                continue
+
+            if not det_id or det_id in self._detection_ids:
+                continue
+
+            self._detection_ids.add(det_id)
+            self._record.detections.append(det if isinstance(det, dict) else {})
+
+            if category:
+                self._record.poi_summary[category] = (
+                    self._record.poi_summary.get(category, 0) + 1
+                )
+            if threat:
+                self._record.threat_summary[threat] = (
+                    self._record.threat_summary.get(threat, 0) + 1
+                )
+
+    def _handle_state_change(self, message: object) -> None:
+        """Log state transitions; capture start/end times on TAKEOFF/LANDING."""
+        if not isinstance(message, dict):
+            return
+
+        from_state = str(message.get("from_state", ""))
+        to_state = str(message.get("to_state", ""))
+        ts = float(message.get("timestamp", time()))
+
+        self._record.state_transitions.append((ts, from_state, to_state))
+
+        if to_state == _TAKEOFF_STATE and self._record.start_time is None:
+            self._record.start_time = ts
+        elif to_state in _LANDING_STATES and self._record.end_time is None:
+            self._record.end_time = ts
+
+    def _handle_telemetry(self, message: object) -> None:
+        """Capture battery level — first reading as start, latest as end."""
+        if isinstance(message, dict):
+            battery = message.get("battery")
+        elif hasattr(message, "battery"):
+            battery = message.battery  # type: ignore[union-attr]
+        else:
+            return
+
+        if not isinstance(battery, int):
+            return
+
+        if self._record.battery_start is None:
+            self._record.battery_start = battery
+        self._record.battery_end = battery
+
+    def _handle_nav_decision(self, _message: object) -> None:
+        """Increment nav decision counter."""
+        self._record.nav_decisions += 1

--- a/src/breacheye/rafa/orchestrator.py
+++ b/src/breacheye/rafa/orchestrator.py
@@ -32,10 +32,12 @@ from breacheye.rafa.schemas import (
     NavigationAction,
     ModelStatus,
     NavigationOutput,
+    ObstacleAlert,
     SpatialNavigationContext,
     Throughput,
 )
-from breacheye.rafa.spatial_context import build_spatial_context, summarize_spatial_context
+from breacheye.rafa.depth_accumulator import DepthAccumulator
+from breacheye.rafa.spatial_context import build_obstacle_alert, build_spatial_context, summarize_spatial_context
 
 
 @dataclass(frozen=True)
@@ -71,6 +73,7 @@ class RafaPipeline:
         )
         self._started_at = monotonic()
         self._last_health_at = 0.0
+        self._depth_accumulator = DepthAccumulator()
         self.errors = list(self.config.errors)
         self.logger = RunLogger("rafa", log_dir=self.config.log_dir, run_id=self.config.run_id)
         self.detector = StubDetector()
@@ -241,6 +244,19 @@ class RafaPipeline:
         timings["depth_ms"] = _elapsed_ms(stage_started_at)
         if depth is not None:
             self._log_depth_artifact(depth)
+            self._accumulate_depth(depth)
+        obstacle_alert: ObstacleAlert | None = None
+        if depth is not None:
+            obstacle_alert = build_obstacle_alert(depth, frame_ts=frame_meta.timestamp)
+            self.logger.event(
+                "obstacle_alert",
+                frame_id=frame_meta.frame_id,
+                obstacle_detected=obstacle_alert.obstacle_detected,
+                direction_hint=obstacle_alert.direction_hint,
+                min_depth=obstacle_alert.min_depth,
+                mean_center_depth=obstacle_alert.mean_center_depth,
+                clearance_score=obstacle_alert.clearance_score,
+            )
         stage_started_at = monotonic()
         navigation = await self._safe_navigation(frame, frame_meta, detection, depth)
         timings["navigation_ms"] = _elapsed_ms(stage_started_at)
@@ -248,6 +264,8 @@ class RafaPipeline:
         await self._publish("detections", detection)
         if depth is not None:
             await self._publish("depth", depth)
+        if obstacle_alert is not None:
+            await self._publish("detections", obstacle_alert)
         await self._publish("navigation", navigation)
         timings["publish_ms"] = _elapsed_ms(stage_started_at)
         self.logger.event(
@@ -369,6 +387,29 @@ class RafaPipeline:
                 fallback=True,
             )
             return fallback
+
+    @property
+    def depth_accumulator(self) -> DepthAccumulator:
+        """Accumulated depth samples keyed by heading estimate."""
+        return self._depth_accumulator
+
+    def _accumulate_depth(self, depth: DepthOutput) -> None:
+        """Feed a depth frame into the accumulator with the current yaw estimate."""
+        try:
+            import numpy as np
+
+            yaw_deg = float(
+                self._search_tactic.heading_index * self._search_tactic.scan_degrees
+            )
+            values = np.frombuffer(depth.depth_bytes, dtype=np.float32).reshape(depth.shape)
+            self._depth_accumulator.add_sample(
+                frame_id=depth.frame_id,
+                timestamp=depth.timestamp,
+                yaw_deg=yaw_deg,
+                depth_array=values,
+            )
+        except Exception as exc:
+            self.logger.event("depth_accumulation_failed", frame_id=depth.frame_id, error=str(exc))
 
     def _apply_navigation_safety_override(
         self,

--- a/src/breacheye/rafa/orchestrator.py
+++ b/src/breacheye/rafa/orchestrator.py
@@ -185,6 +185,7 @@ class RafaPipeline:
             else:
                 socket.connect(endpoint)
             self._sockets[name] = socket
+        self._sockets["obstacle_alert"] = self._sockets["detections"]
         self._running = True
         await asyncio.sleep(0.05)
         await self.publish_health()
@@ -265,7 +266,7 @@ class RafaPipeline:
         if depth is not None:
             await self._publish("depth", depth)
         if obstacle_alert is not None:
-            await self._publish("detections", obstacle_alert)
+            await self._publish("obstacle_alert", obstacle_alert)
         await self._publish("navigation", navigation)
         timings["publish_ms"] = _elapsed_ms(stage_started_at)
         self.logger.event(

--- a/src/breacheye/rafa/schemas.py
+++ b/src/breacheye/rafa/schemas.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 PoiCategory = Literal["T1-01", "T1-02", "T1-03", "T2-02", "T2-03", "T3-01", "T4-01", "ROOM"]
 ThreatLevel = Literal["HOT", "WARM", "CAUTION", "CLEAR", "INFO"]
+ObstacleDirection = Literal["center", "left", "right", "unknown"]
 NavigationAction = Literal[
     "move_forward",
     "move_back",
@@ -112,6 +113,16 @@ class DepthOutput(StrictModel):
         return self
 
 
+class ObstacleAlert(StrictModel):
+    frame_id: int = Field(ge=0)
+    timestamp: float = Field(default_factory=time)
+    min_depth: float = Field(ge=0.0, le=1.0)
+    mean_center_depth: float = Field(ge=0.0, le=1.0)
+    obstacle_detected: bool
+    direction_hint: ObstacleDirection
+    clearance_score: float = Field(ge=0.0, le=1.0)
+
+
 class NavigationDecision(StrictModel):
     action: NavigationAction
     params: dict[str, int | float | str] = Field(default_factory=dict)
@@ -165,6 +176,7 @@ class SpatialNavigationContext(StrictModel):
     allowed_actions: list[NavigationAction] = Field(
         default_factory=lambda: ["hover", "move_forward", "rotate_left", "rotate_right"]
     )
+    obstacle_alert: ObstacleAlert | None = None
     source: str = "stub"
 
 

--- a/src/breacheye/rafa/spatial_context.py
+++ b/src/breacheye/rafa/spatial_context.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 import os
 from time import time
+
+logger = logging.getLogger(__name__)
 
 from breacheye.rafa.schemas import (
     DepthOutput,
@@ -180,6 +183,7 @@ def build_obstacle_alert(
             clearance_score=clearance_score,
         )
     except Exception:
+        logger.warning("build_obstacle_alert failed — returning unknown clearance", exc_info=True)
         return ObstacleAlert(
             frame_id=depth.frame_id,
             timestamp=frame_ts if frame_ts is not None else time(),

--- a/src/breacheye/rafa/spatial_context.py
+++ b/src/breacheye/rafa/spatial_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from time import time
 
 from breacheye.rafa.schemas import (
     DepthOutput,
@@ -11,6 +12,8 @@ from breacheye.rafa.schemas import (
     MapObject,
     MapPose,
     NavigationAction,
+    ObstacleAlert,
+    ObstacleDirection,
     SpatialNavigationContext,
 )
 
@@ -44,6 +47,7 @@ def build_spatial_context(
                 label="open forward view",
             )
         )
+    alert = build_obstacle_alert(depth, frame_ts=meta.timestamp) if depth is not None else None
     return SpatialNavigationContext(
         frame_id=meta.frame_id,
         current_pose=MapPose(source="unavailable"),
@@ -56,6 +60,7 @@ def build_spatial_context(
         unexplored_frontiers=frontiers,
         known_objects=objects,
         recent_actions=recent_actions[-8:],
+        obstacle_alert=alert,
         source="stub_from_current_frame",
     )
 
@@ -101,6 +106,89 @@ def _nearest_center_depth(depth: DepthOutput | None) -> float | None:
         return min(scores)
     except Exception:
         return None
+
+
+_OBSTACLE_THRESHOLD = 0.15
+
+
+def build_obstacle_alert(
+    depth: DepthOutput,
+    *,
+    threshold: float = _OBSTACLE_THRESHOLD,
+    frame_ts: float | None = None,
+) -> ObstacleAlert:
+    """Compute an ObstacleAlert from a depth map.
+
+    Depth values are in relative 0-near/1-far space. An obstacle is detected
+    when the nearest forward-region depth falls below *threshold* (default 0.15).
+    Direction hint is determined by comparing per-column-third medians.
+    Clearance score is the clamped inverse of obstacle proximity (1.0 = fully
+    clear, 0.0 = obstacle at sensor minimum).
+    """
+    try:
+        import numpy as np
+
+        values = np.frombuffer(depth.depth_bytes, dtype=np.float32).reshape(depth.shape)
+        height, width = values.shape
+
+        # Center band used for mean_center_depth
+        center_rows = values[height // 3 : (height * 2) // 3, width // 3 : (width * 2) // 3]
+        center_finite = center_rows[np.isfinite(center_rows)]
+        mean_center = float(np.nanmean(center_finite)) if center_finite.size else 1.0
+
+        # Forward region: lower-center strip captures the actual flight path
+        forward = values[
+            int(height * 0.45) : int(height * 0.9),
+            int(width * 0.25) : int(width * 0.75),
+        ]
+        forward_finite = forward[np.isfinite(forward)]
+        min_depth = float(np.nanmin(forward_finite)) if forward_finite.size else 1.0
+
+        obstacle_detected = min_depth < threshold
+
+        # Direction: compare 2nd-percentile of left / center / right thirds of forward region
+        fw_h, fw_w = forward.shape
+        col_third = fw_w // 3
+        def _region_min(region: "np.ndarray") -> float:  # type: ignore[type-arg]
+            finite = region[np.isfinite(region)]
+            return float(np.nanpercentile(finite, 2)) if finite.size else 1.0
+
+        left_min = _region_min(forward[:, :col_third])
+        center_min = _region_min(forward[:, col_third : col_third * 2])
+        right_min = _region_min(forward[:, col_third * 2 :])
+
+        direction: ObstacleDirection
+        if obstacle_detected:
+            closest = min(left_min, center_min, right_min)
+            if closest == center_min:
+                direction = "center"
+            elif closest == left_min:
+                direction = "left"
+            else:
+                direction = "right"
+        else:
+            direction = "unknown"
+
+        clearance_score = float(np.clip((min_depth - threshold) / max(1.0 - threshold, 1e-6), 0.0, 1.0))
+        return ObstacleAlert(
+            frame_id=depth.frame_id,
+            timestamp=frame_ts if frame_ts is not None else time(),
+            min_depth=float(np.clip(min_depth, 0.0, 1.0)),
+            mean_center_depth=float(np.clip(mean_center, 0.0, 1.0)),
+            obstacle_detected=obstacle_detected,
+            direction_hint=direction,
+            clearance_score=clearance_score,
+        )
+    except Exception:
+        return ObstacleAlert(
+            frame_id=depth.frame_id,
+            timestamp=frame_ts if frame_ts is not None else time(),
+            min_depth=1.0,
+            mean_center_depth=1.0,
+            obstacle_detected=False,
+            direction_hint="unknown",
+            clearance_score=1.0,
+        )
 
 
 def _bbox_relative_position(x1: int, x2: int, width: int | None) -> str:

--- a/src/breacheye/report.py
+++ b/src/breacheye/report.py
@@ -1,0 +1,63 @@
+"""Building report schema definitions.
+
+Canonical report that captures a full building assessment after a drone
+flight.  Consumed by CLI, frontend, and optionally Palantir.
+"""
+
+from __future__ import annotations
+
+from pydantic import ConfigDict, BaseModel, Field
+
+from breacheye.rafa.schemas import ThreatLevel
+
+
+__all__ = [
+    "RoomSummary",
+    "ThreatSummary",
+    "FlightSummary",
+    "BuildingReport",
+]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class RoomSummary(_StrictModel):
+    room_id: str
+    poi_count: int = Field(ge=0)
+    threat_level: ThreatLevel
+    coverage_pct: float = Field(ge=0.0, le=100.0)
+    entry_points: list[str] = Field(default_factory=list)
+    dimensions_estimate: dict | None = None
+
+
+class ThreatSummary(_StrictModel):
+    total_pois: int = Field(ge=0)
+    by_category: dict[str, int] = Field(default_factory=dict)
+    by_threat_level: dict[str, int] = Field(default_factory=dict)
+    high_priority_items: list[dict] = Field(default_factory=list)
+
+
+class FlightSummary(_StrictModel):
+    run_id: str
+    start_time: float
+    end_time: float
+    duration_s: float = Field(ge=0.0)
+    frames_processed: int = Field(ge=0)
+    detections_total: int = Field(ge=0)
+    nav_decisions_total: int = Field(ge=0)
+    distance_estimate_m: float | None = Field(default=None, ge=0.0)
+    battery_start: int | None = Field(default=None, ge=0, le=100)
+    battery_end: int | None = Field(default=None, ge=0, le=100)
+
+
+class BuildingReport(_StrictModel):
+    report_id: str
+    generated_at: float
+    flight: FlightSummary
+    rooms: list[RoomSummary] = Field(default_factory=list)
+    threats: ThreatSummary
+    recommended_entry: str | None = None
+    chokepoints: list[str] = Field(default_factory=list)
+    narrative: str = ""

--- a/src/breacheye/report_generator.py
+++ b/src/breacheye/report_generator.py
@@ -1,0 +1,326 @@
+"""Post-flight building report generator.
+
+Takes a BuildingReport and produces formatted output for terminal display.
+Optionally calls Qwen 3-VL (via its OpenAI-compatible server) to generate
+a natural-language narrative summary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+import urllib.error
+from datetime import datetime, UTC
+from typing import Any
+
+from breacheye.report import BuildingReport
+
+
+__all__ = ["ReportGenerator"]
+
+
+class ReportGenerator:
+    """Formats BuildingReport data for human consumption.
+
+    Works standalone (structured text output) and optionally enhances the
+    report with a Qwen-generated narrative when a server URL is configured.
+    """
+
+    def generate_text_report(self, report: BuildingReport) -> str:
+        """Format a BuildingReport as human-readable text for terminal display."""
+        lines: list[str] = []
+
+        # ------------------------------------------------------------------ #
+        # Header
+        # ------------------------------------------------------------------ #
+        lines.append("=" * 70)
+        lines.append("BREACHEYE BUILDING ASSESSMENT REPORT")
+        lines.append("=" * 70)
+        lines.append(f"Report ID  : {report.report_id}")
+        generated = datetime.fromtimestamp(report.generated_at, tz=UTC).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        lines.append(f"Generated  : {generated}")
+
+        # ------------------------------------------------------------------ #
+        # Flight Stats
+        # ------------------------------------------------------------------ #
+        lines.append("")
+        lines.append("FLIGHT STATS")
+        lines.append("-" * 40)
+        flight = report.flight
+        lines.append(f"Run ID          : {flight.run_id}")
+        start_dt = datetime.fromtimestamp(flight.start_time, tz=UTC).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        end_dt = datetime.fromtimestamp(flight.end_time, tz=UTC).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        lines.append(f"Start           : {start_dt}")
+        lines.append(f"End             : {end_dt}")
+        lines.append(f"Duration        : {flight.duration_s:.1f}s")
+        lines.append(f"Frames Processed: {flight.frames_processed}")
+        lines.append(f"Detections      : {flight.detections_total}")
+        lines.append(f"Nav Decisions   : {flight.nav_decisions_total}")
+        if flight.distance_estimate_m is not None:
+            lines.append(f"Distance Est.   : {flight.distance_estimate_m:.1f} m")
+        if flight.battery_start is not None and flight.battery_end is not None:
+            usage = flight.battery_start - flight.battery_end
+            lines.append(
+                f"Battery         : {flight.battery_start}% -> {flight.battery_end}%"
+                f" ({usage:+d}%)"
+            )
+        elif flight.battery_start is not None:
+            lines.append(f"Battery Start   : {flight.battery_start}%")
+        elif flight.battery_end is not None:
+            lines.append(f"Battery End     : {flight.battery_end}%")
+
+        # ------------------------------------------------------------------ #
+        # Threat Assessment
+        # ------------------------------------------------------------------ #
+        lines.append("")
+        lines.append("THREAT ASSESSMENT")
+        lines.append("-" * 40)
+        threats = report.threats
+        lines.append(f"Total POIs: {threats.total_pois}")
+
+        if threats.by_category:
+            lines.append("By Category:")
+            for category, count in sorted(threats.by_category.items()):
+                lines.append(f"  {category:<12} {count}")
+
+        if threats.by_threat_level:
+            lines.append("By Threat Level:")
+            level_order = ["HOT", "WARM", "CAUTION", "CLEAR", "INFO"]
+            present = {k: v for k, v in threats.by_threat_level.items()}
+            for level in level_order:
+                if level in present:
+                    lines.append(f"  {level:<12} {present[level]}")
+            for level, count in sorted(present.items()):
+                if level not in level_order:
+                    lines.append(f"  {level:<12} {count}")
+
+        if threats.high_priority_items:
+            lines.append(f"High-Priority Items ({len(threats.high_priority_items)}):")
+            for item in threats.high_priority_items:
+                label = item.get("label", item.get("id", "unknown"))
+                threat = item.get("threat_level", "")
+                location = item.get("location", "")
+                detail = f"[{threat}]" if threat else ""
+                if location:
+                    detail = f"{detail} @ {location}" if detail else f"@ {location}"
+                lines.append(f"  * {label} {detail}".rstrip())
+
+        # ------------------------------------------------------------------ #
+        # Rooms
+        # ------------------------------------------------------------------ #
+        if report.rooms:
+            lines.append("")
+            lines.append("ROOM SUMMARY")
+            lines.append("-" * 40)
+            for room in report.rooms:
+                lines.append(f"Room {room.room_id}:")
+                lines.append(f"  Threat Level : {room.threat_level}")
+                lines.append(f"  POI Count    : {room.poi_count}")
+                lines.append(f"  Coverage     : {room.coverage_pct:.1f}%")
+                if room.entry_points:
+                    lines.append(f"  Entry Points : {', '.join(room.entry_points)}")
+                if room.dimensions_estimate:
+                    dims = ", ".join(
+                        f"{k}={v}" for k, v in room.dimensions_estimate.items()
+                    )
+                    lines.append(f"  Dimensions   : {dims}")
+
+        # ------------------------------------------------------------------ #
+        # Recommendations
+        # ------------------------------------------------------------------ #
+        lines.append("")
+        lines.append("RECOMMENDATIONS")
+        lines.append("-" * 40)
+        if report.recommended_entry:
+            lines.append(f"Recommended Entry Point : {report.recommended_entry}")
+        else:
+            lines.append("Recommended Entry Point : N/A")
+
+        if report.chokepoints:
+            lines.append("Chokepoints:")
+            for cp in report.chokepoints:
+                lines.append(f"  * {cp}")
+        else:
+            lines.append("Chokepoints: none identified")
+
+        # ------------------------------------------------------------------ #
+        # Narrative (if present on the report object)
+        # ------------------------------------------------------------------ #
+        if report.narrative:
+            lines.append("")
+            lines.append("NARRATIVE SUMMARY")
+            lines.append("-" * 40)
+            lines.append(report.narrative)
+
+        lines.append("")
+        lines.append("=" * 70)
+
+        return "\n".join(lines)
+
+    async def generate_narrative(
+        self,
+        report: BuildingReport,
+        keyframes: list[bytes] | None = None,
+    ) -> str:
+        """Generate a tactical narrative summary using Qwen 3-VL.
+
+        Falls back to an auto-generated summary from structured data if Qwen
+        is unavailable.
+
+        Args:
+            report: The BuildingReport to summarize.
+            keyframes: Optional JPEG keyframes (currently unused; reserved for
+                future multimodal support).
+
+        Returns:
+            A 3-5 sentence tactical narrative string.
+        """
+        server_url = os.environ.get("BREACHEYE_QWEN_SERVER_URL")
+        if server_url:
+            try:
+                return await self._call_qwen_server(report, server_url)
+            except Exception:
+                pass
+
+        return self._fallback_narrative(report)
+
+    async def _call_qwen_server(
+        self, report: BuildingReport, server_url: str
+    ) -> str:
+        """Call the Qwen OpenAI-compatible server for a narrative summary."""
+        import asyncio
+
+        report_context = _build_report_context(report)
+        prompt = (
+            "You are a tactical intelligence analyst. Based on the following building "
+            "assessment data, provide a 3-5 sentence tactical summary including key "
+            "threats, recommended approach, and areas of concern.\n\n"
+            f"{report_context}"
+        )
+        payload = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "max_tokens": int(os.environ.get("BREACHEYE_QWEN_MAX_TOKENS", "256")),
+        }
+        request = urllib.request.Request(
+            server_url.rstrip("/") + "/v1/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+        timeout = float(os.environ.get("BREACHEYE_QWEN_TIMEOUT_S", "20"))
+
+        def _call() -> str:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                data = json.loads(response.read().decode("utf-8"))
+            return data["choices"][0]["message"]["content"].strip()
+
+        return await asyncio.to_thread(_call)
+
+    def _fallback_narrative(self, report: BuildingReport) -> str:
+        """Generate a rule-based fallback narrative from structured data."""
+        flight = report.flight
+        threats = report.threats
+
+        hot_count = threats.by_threat_level.get("HOT", 0)
+        warm_count = threats.by_threat_level.get("WARM", 0)
+        room_count = len(report.rooms)
+
+        parts: list[str] = []
+
+        # Sentence 1: flight overview
+        parts.append(
+            f"Flight {flight.run_id} completed in {flight.duration_s:.0f} seconds, "
+            f"processing {flight.frames_processed} frames and recording "
+            f"{threats.total_pois} points of interest."
+        )
+
+        # Sentence 2: threat summary
+        if hot_count > 0:
+            parts.append(
+                f"Critical threat assessment: {hot_count} HOT and {warm_count} WARM "
+                f"contacts identified — immediate tactical attention required."
+            )
+        elif warm_count > 0:
+            parts.append(
+                f"Elevated threat level: {warm_count} WARM contacts identified; "
+                f"proceed with caution."
+            )
+        else:
+            parts.append("No high-priority threats detected during this assessment.")
+
+        # Sentence 3: rooms / areas
+        if room_count > 0:
+            covered = [r for r in report.rooms if r.coverage_pct >= 80.0]
+            parts.append(
+                f"{room_count} area{'s' if room_count != 1 else ''} assessed"
+                + (
+                    f", {len(covered)} with ≥80% coverage"
+                    if covered
+                    else ""
+                )
+                + "."
+            )
+
+        # Sentence 4: entry / chokepoints
+        if report.recommended_entry:
+            cp_note = ""
+            if report.chokepoints:
+                cp_note = (
+                    f"; monitor chokepoint{'s' if len(report.chokepoints) != 1 else ''} "
+                    + ", ".join(report.chokepoints)
+                )
+            parts.append(
+                f"Recommended entry via {report.recommended_entry}{cp_note}."
+            )
+        elif report.chokepoints:
+            parts.append(
+                "Key chokepoints identified: "
+                + ", ".join(report.chokepoints)
+                + "."
+            )
+
+        return " ".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _build_report_context(report: BuildingReport) -> str:
+    """Serialize BuildingReport to a compact text block for the Qwen prompt."""
+    flight = report.flight
+    threats = report.threats
+    lines: list[str] = [
+        f"run_id={flight.run_id}",
+        f"duration={flight.duration_s:.0f}s",
+        f"frames={flight.frames_processed}",
+        f"total_pois={threats.total_pois}",
+        "by_threat_level=" + json.dumps(threats.by_threat_level),
+        "by_category=" + json.dumps(threats.by_category),
+    ]
+    if report.rooms:
+        room_summaries = [
+            f"{r.room_id}:threat={r.threat_level},pois={r.poi_count},coverage={r.coverage_pct:.0f}%"
+            for r in report.rooms
+        ]
+        lines.append("rooms=" + "; ".join(room_summaries))
+    if report.recommended_entry:
+        lines.append(f"recommended_entry={report.recommended_entry}")
+    if report.chokepoints:
+        lines.append("chokepoints=" + ", ".join(report.chokepoints))
+    if threats.high_priority_items:
+        items = [
+            item.get("label", item.get("id", "?")) + f"[{item.get('threat_level', '')}]"
+            for item in threats.high_priority_items
+        ]
+        lines.append("high_priority=" + "; ".join(items))
+    return "\n".join(lines)

--- a/src/breacheye/service.py
+++ b/src/breacheye/service.py
@@ -16,6 +16,7 @@ from breacheye.adapters.sim import SimAdapter
 from breacheye.adapters.tello import TelloAdapter
 from breacheye.battery_monitor import BatteryMonitor
 from breacheye.bus import AsyncEventBus
+from breacheye.flight_record import FlightDataAccumulator
 from breacheye.models import CommandResult, CommandStatus, CommandType, DroneCommand
 from breacheye.operator import OperatorCommand, OperatorHandler
 from breacheye.safety import SafetyController
@@ -40,6 +41,10 @@ class HarnessRuntime:
         self.fsm = FlightStateMachine(self.adapter, self.bus)
         self.safety = SafetyController(self.adapter, self.bus)
         self.battery_monitor = BatteryMonitor(self.fsm, self.adapter, self.bus)
+        self.accumulator = FlightDataAccumulator(
+            self.bus,
+            run_id=os.environ.get("BREACHEYE_RUN_ID", "unknown"),
+        )
         self.video_pump: TelloVideoPump | None = None
         self._zmq_task: asyncio.Task | None = None
         self._zmq_socket = None
@@ -49,6 +54,7 @@ class HarnessRuntime:
         await self.adapter.connect()
         await self.safety.start()
         await self.battery_monitor.start()
+        await self.accumulator.start()
         if self.mode == "tello" and self.start_video_on_start:
             await self.start_video()
         self._start_zmq_bridge()
@@ -140,6 +146,7 @@ class HarnessRuntime:
             self._zmq_task = None
         self._cleanup_zmq()
         await self.stop_video()
+        await self.accumulator.stop()
         await self.battery_monitor.stop()
         await self.safety.stop()
         await self.adapter.close()
@@ -201,6 +208,10 @@ def create_app(mode: str = "sim", *, start_video_on_start: bool = True) -> FastA
                 ),
             },
         }
+
+    @app.get("/report")
+    async def get_report():
+        return runtime.accumulator.to_building_report().model_dump()
 
     @app.post("/video/start")
     async def start_video():

--- a/tests/test_building_report.py
+++ b/tests/test_building_report.py
@@ -1,0 +1,193 @@
+"""Tests for the building report schema."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from breacheye.report import (
+    BuildingReport,
+    FlightSummary,
+    RoomSummary,
+    ThreatSummary,
+)
+
+
+def _make_flight() -> FlightSummary:
+    return FlightSummary(
+        run_id="run-001",
+        start_time=1746200000.0,
+        end_time=1746200120.0,
+        duration_s=120.0,
+        frames_processed=3600,
+        detections_total=14,
+        nav_decisions_total=240,
+        distance_estimate_m=45.5,
+        battery_start=95,
+        battery_end=72,
+    )
+
+
+def _make_threats() -> ThreatSummary:
+    return ThreatSummary(
+        total_pois=14,
+        by_category={"T1-01": 3, "T2-02": 2, "ROOM": 9},
+        by_threat_level={"HOT": 1, "WARM": 4, "CLEAR": 9},
+        high_priority_items=[
+            {
+                "id": "det-001",
+                "label": "Armed individual",
+                "threat_level": "HOT",
+                "location": "room-2",
+            }
+        ],
+    )
+
+
+def test_room_summary_construction() -> None:
+    room = RoomSummary(
+        room_id="room-1",
+        poi_count=3,
+        threat_level="WARM",
+        coverage_pct=87.5,
+        entry_points=["door-north", "window-east"],
+        dimensions_estimate={"width_m": 4.2, "depth_m": 6.1},
+    )
+
+    assert room.room_id == "room-1"
+    assert room.poi_count == 3
+    assert room.threat_level == "WARM"
+    assert room.coverage_pct == 87.5
+    assert "door-north" in room.entry_points
+    assert room.dimensions_estimate is not None
+
+
+def test_room_summary_optional_dimensions_defaults_none() -> None:
+    room = RoomSummary(
+        room_id="room-2",
+        poi_count=0,
+        threat_level="CLEAR",
+        coverage_pct=100.0,
+    )
+
+    assert room.dimensions_estimate is None
+    assert room.entry_points == []
+
+
+def test_threat_summary_construction() -> None:
+    threats = _make_threats()
+
+    assert threats.total_pois == 14
+    assert threats.by_category["T1-01"] == 3
+    assert threats.by_threat_level["HOT"] == 1
+    assert len(threats.high_priority_items) == 1
+
+
+def test_flight_summary_construction() -> None:
+    flight = _make_flight()
+
+    assert flight.run_id == "run-001"
+    assert flight.duration_s == 120.0
+    assert flight.battery_start == 95
+    assert flight.battery_end == 72
+
+
+def test_flight_summary_optional_fields_default_none() -> None:
+    flight = FlightSummary(
+        run_id="run-minimal",
+        start_time=1746200000.0,
+        end_time=1746200060.0,
+        duration_s=60.0,
+        frames_processed=0,
+        detections_total=0,
+        nav_decisions_total=0,
+    )
+
+    assert flight.distance_estimate_m is None
+    assert flight.battery_start is None
+    assert flight.battery_end is None
+
+
+def test_building_report_construction() -> None:
+    report = BuildingReport(
+        report_id="rpt-abc123",
+        generated_at=1746200200.0,
+        flight=_make_flight(),
+        rooms=[
+            RoomSummary(
+                room_id="room-1",
+                poi_count=5,
+                threat_level="HOT",
+                coverage_pct=92.0,
+                entry_points=["main-door"],
+            ),
+            RoomSummary(
+                room_id="room-2",
+                poi_count=1,
+                threat_level="WARM",
+                coverage_pct=78.0,
+            ),
+        ],
+        threats=_make_threats(),
+        recommended_entry="main-door",
+        chokepoints=["hallway-junction-A"],
+        narrative="Two rooms assessed. One HOT contact in room-2.",
+    )
+
+    assert report.report_id == "rpt-abc123"
+    assert len(report.rooms) == 2
+    assert report.recommended_entry == "main-door"
+    assert "HOT" in report.narrative
+
+
+def test_building_report_serializes_to_json() -> None:
+    report = BuildingReport(
+        report_id="rpt-serial",
+        generated_at=1746200300.0,
+        flight=_make_flight(),
+        threats=_make_threats(),
+    )
+
+    payload = json.loads(report.model_dump_json())
+
+    assert payload["report_id"] == "rpt-serial"
+    assert payload["rooms"] == []
+    assert payload["chokepoints"] == []
+    assert payload["narrative"] == ""
+    assert payload["recommended_entry"] is None
+    assert payload["flight"]["run_id"] == "run-001"
+    assert payload["threats"]["total_pois"] == 14
+
+
+def test_building_report_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        BuildingReport(
+            report_id="rpt-bad",
+            generated_at=1.0,
+            flight=_make_flight(),
+            threats=_make_threats(),
+            unknown_field="oops",
+        )
+
+
+def test_room_summary_rejects_invalid_threat_level() -> None:
+    with pytest.raises(ValidationError):
+        RoomSummary(
+            room_id="x",
+            poi_count=0,
+            threat_level="UNKNOWN",
+            coverage_pct=50.0,
+        )
+
+
+def test_flight_summary_rejects_negative_duration() -> None:
+    with pytest.raises(ValidationError):
+        FlightSummary(
+            run_id="bad",
+            start_time=1.0,
+            end_time=0.0,
+            duration_s=-1.0,
+            frames_processed=0,
+            detections_total=0,
+            nav_decisions_total=0,
+        )

--- a/tests/test_flight_record.py
+++ b/tests/test_flight_record.py
@@ -1,0 +1,367 @@
+"""Tests for FlightDataAccumulator and FlightRecord."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+
+from breacheye.bus import AsyncEventBus
+from breacheye.flight_record import FlightDataAccumulator, FlightRecord
+from breacheye.models import DroneTelemetry
+from breacheye.report import BuildingReport
+
+
+def _make_detection_payload(det_id: str, category: str = "T1-01", threat: str = "HOT") -> dict:
+    """Build a drone.detections payload dict."""
+    return {
+        "frame_id": 1,
+        "timestamp": 1746200000.0,
+        "detections": [
+            {
+                "id": det_id,
+                "category": category,
+                "label": "Armed individual",
+                "description": "",
+                "confidence": 0.92,
+                "bbox_2d": {"x1": 10, "y1": 20, "x2": 100, "y2": 200},
+                "threat_level": threat,
+                "detection_model": "moondream-photon",
+            }
+        ],
+        "processing_ms": 18,
+    }
+
+
+def _make_state_change(from_state: str, to_state: str, ts: float = 1746200000.0) -> dict:
+    return {"from_state": from_state, "to_state": to_state, "timestamp": ts}
+
+
+def _make_telemetry(battery: int) -> DroneTelemetry:
+    return DroneTelemetry(battery=battery, connected=True)
+
+
+async def _make_accumulator() -> tuple[FlightDataAccumulator, AsyncEventBus]:
+    bus = AsyncEventBus()
+    acc = FlightDataAccumulator(bus, run_id="test-run-001")
+    await acc.start()
+    return acc, bus
+
+
+async def test_accumulator_starts_and_stops() -> None:
+    acc, _ = await _make_accumulator()
+    await acc.stop()
+    rec = acc.get_record()
+    assert rec.run_id == "test-run-001"
+
+
+async def test_single_detection_recorded() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.detections", _make_detection_payload("det-001"))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert len(rec.detections) == 1
+        assert rec.detections[0]["id"] == "det-001"
+    finally:
+        await acc.stop()
+
+
+async def test_detection_deduplication_by_id() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        # Publish same detection id twice — should only count once
+        await bus.publish("drone.detections", _make_detection_payload("det-dup"))
+        await bus.publish("drone.detections", _make_detection_payload("det-dup"))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert len(rec.detections) == 1
+    finally:
+        await acc.stop()
+
+
+async def test_different_detection_ids_both_recorded() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.detections", _make_detection_payload("det-A"))
+        await bus.publish("drone.detections", _make_detection_payload("det-B"))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert len(rec.detections) == 2
+    finally:
+        await acc.stop()
+
+
+async def test_poi_summary_counts_by_category() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        payload = {
+            "frame_id": 1,
+            "timestamp": 1746200000.0,
+            "detections": [
+                {
+                    "id": "d1",
+                    "category": "T1-01",
+                    "label": "test",
+                    "description": "",
+                    "confidence": 0.9,
+                    "bbox_2d": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+                    "threat_level": "HOT",
+                    "detection_model": "stub",
+                },
+                {
+                    "id": "d2",
+                    "category": "T2-02",
+                    "label": "test",
+                    "description": "",
+                    "confidence": 0.8,
+                    "bbox_2d": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+                    "threat_level": "WARM",
+                    "detection_model": "stub",
+                },
+                {
+                    "id": "d3",
+                    "category": "T1-01",
+                    "label": "test",
+                    "description": "",
+                    "confidence": 0.7,
+                    "bbox_2d": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+                    "threat_level": "CAUTION",
+                    "detection_model": "stub",
+                },
+            ],
+            "processing_ms": 20,
+        }
+        await bus.publish("drone.detections", payload)
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.poi_summary["T1-01"] == 2
+        assert rec.poi_summary["T2-02"] == 1
+    finally:
+        await acc.stop()
+
+
+async def test_threat_summary_counts_by_level() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        payload = {
+            "frame_id": 1,
+            "timestamp": 1746200000.0,
+            "detections": [
+                {
+                    "id": "ta1",
+                    "category": "T1-01",
+                    "label": "t",
+                    "description": "",
+                    "confidence": 0.9,
+                    "bbox_2d": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+                    "threat_level": "HOT",
+                    "detection_model": "stub",
+                },
+                {
+                    "id": "ta2",
+                    "category": "T2-02",
+                    "label": "t",
+                    "description": "",
+                    "confidence": 0.8,
+                    "bbox_2d": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+                    "threat_level": "HOT",
+                    "detection_model": "stub",
+                },
+                {
+                    "id": "ta3",
+                    "category": "ROOM",
+                    "label": "r",
+                    "description": "",
+                    "confidence": 0.6,
+                    "bbox_2d": {"x1": 0, "y1": 0, "x2": 10, "y2": 10},
+                    "threat_level": "CLEAR",
+                    "detection_model": "stub",
+                },
+            ],
+            "processing_ms": 20,
+        }
+        await bus.publish("drone.detections", payload)
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.threat_summary["HOT"] == 2
+        assert rec.threat_summary["CLEAR"] == 1
+    finally:
+        await acc.stop()
+
+
+async def test_frames_processed_increments_per_payload() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        for _ in range(3):
+            await bus.publish("drone.detections", _make_detection_payload(str(uuid.uuid4())))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.frames_processed == 3
+    finally:
+        await acc.stop()
+
+
+async def test_state_transition_logged() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.state_change", _make_state_change("preflight", "takeoff", 1746200001.0))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert len(rec.state_transitions) == 1
+        ts, from_s, to_s = rec.state_transitions[0]
+        assert ts == 1746200001.0
+        assert from_s == "preflight"
+        assert to_s == "takeoff"
+    finally:
+        await acc.stop()
+
+
+async def test_start_time_set_on_takeoff() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.state_change", _make_state_change("preflight", "takeoff", 1746200010.0))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.start_time == 1746200010.0
+    finally:
+        await acc.stop()
+
+
+async def test_start_time_not_overwritten_on_second_takeoff() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.state_change", _make_state_change("preflight", "takeoff", 1746200010.0))
+        await bus.publish("drone.state_change", _make_state_change("preflight", "takeoff", 1746200099.0))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.start_time == 1746200010.0
+    finally:
+        await acc.stop()
+
+
+async def test_end_time_set_on_landing() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.state_change", _make_state_change("returning", "landing", 1746200120.0))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.end_time == 1746200120.0
+    finally:
+        await acc.stop()
+
+
+async def test_end_time_set_on_complete() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.state_change", _make_state_change("landing", "complete", 1746200125.0))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.end_time == 1746200125.0
+    finally:
+        await acc.stop()
+
+
+async def test_battery_start_and_end_captured() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.telemetry", _make_telemetry(95))
+        await bus.publish("drone.telemetry", _make_telemetry(88))
+        await bus.publish("drone.telemetry", _make_telemetry(74))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.battery_start == 95
+        assert rec.battery_end == 74
+    finally:
+        await acc.stop()
+
+
+async def test_battery_start_preserved_after_updates() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.telemetry", _make_telemetry(100))
+        await bus.publish("drone.telemetry", _make_telemetry(50))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.battery_start == 100
+        assert rec.battery_end == 50
+    finally:
+        await acc.stop()
+
+
+async def test_nav_decisions_counted() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        for _ in range(5):
+            await bus.publish("drone.nav_decision", {"frame_id": 1, "decision": {}})
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert rec.nav_decisions == 5
+    finally:
+        await acc.stop()
+
+
+async def test_to_building_report_returns_building_report() -> None:
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.state_change", _make_state_change("preflight", "takeoff", 1746200000.0))
+        await bus.publish("drone.state_change", _make_state_change("returning", "landing", 1746200120.0))
+        await bus.publish("drone.detections", _make_detection_payload("det-r1"))
+        await bus.publish("drone.telemetry", _make_telemetry(90))
+        await bus.publish("drone.telemetry", _make_telemetry(75))
+        await bus.publish("drone.nav_decision", {"frame_id": 1, "decision": {}})
+        await asyncio.sleep(0.05)
+
+        report = acc.to_building_report()
+        assert isinstance(report, BuildingReport)
+        assert report.flight.run_id == "test-run-001"
+        assert report.flight.start_time == 1746200000.0
+        assert report.flight.end_time == 1746200120.0
+        assert report.flight.duration_s == 120.0
+        assert report.flight.detections_total == 1
+        assert report.flight.nav_decisions_total == 1
+        assert report.flight.battery_start == 90
+        assert report.flight.battery_end == 75
+        assert report.threats.total_pois == 1
+        assert report.threats.by_threat_level["HOT"] == 1
+    finally:
+        await acc.stop()
+
+
+async def test_to_building_report_serializable() -> None:
+    acc, _ = await _make_accumulator()
+    try:
+        report = acc.to_building_report()
+        payload = report.model_dump()
+        assert "report_id" in payload
+        assert "flight" in payload
+        assert "threats" in payload
+    finally:
+        await acc.stop()
+
+
+async def test_deduplication_across_multiple_payloads() -> None:
+    """Same detection id appearing in two separate payloads counts once."""
+    acc, bus = await _make_accumulator()
+    try:
+        await bus.publish("drone.detections", _make_detection_payload("shared-id"))
+        await bus.publish("drone.detections", _make_detection_payload("shared-id"))
+        await bus.publish("drone.detections", _make_detection_payload("unique-id"))
+        await asyncio.sleep(0.05)
+        rec = acc.get_record()
+        assert len(rec.detections) == 2
+        ids = {d["id"] for d in rec.detections}
+        assert ids == {"shared-id", "unique-id"}
+    finally:
+        await acc.stop()
+
+
+async def test_get_record_returns_same_instance() -> None:
+    acc, _ = await _make_accumulator()
+    try:
+        r1 = acc.get_record()
+        r2 = acc.get_record()
+        assert r1 is r2
+    finally:
+        await acc.stop()

--- a/tests/test_rafa_schemas.py
+++ b/tests/test_rafa_schemas.py
@@ -10,6 +10,7 @@ from breacheye.rafa.schemas import (
     FrameInput,
     NavigationDecision,
     NavigationOutput,
+    ObstacleAlert,
 )
 
 
@@ -59,3 +60,62 @@ def test_frame_requires_jpeg_bytes() -> None:
 def test_depth_rejects_byte_length_mismatch() -> None:
     with pytest.raises(ValidationError):
         DepthOutput(frame_id=1, shape=(2, 2), depth_bytes=b"too-short")
+
+
+def test_obstacle_alert_validates_clear_path() -> None:
+    alert = ObstacleAlert(
+        frame_id=10,
+        timestamp=1746201234.567,
+        min_depth=0.8,
+        mean_center_depth=0.75,
+        obstacle_detected=False,
+        direction_hint="unknown",
+        clearance_score=0.94,
+    )
+
+    assert alert.obstacle_detected is False
+    assert alert.direction_hint == "unknown"
+    assert alert.clearance_score == pytest.approx(0.94)
+
+
+def test_obstacle_alert_validates_obstacle_detected() -> None:
+    alert = ObstacleAlert(
+        frame_id=11,
+        timestamp=1746201234.567,
+        min_depth=0.08,
+        mean_center_depth=0.12,
+        obstacle_detected=True,
+        direction_hint="center",
+        clearance_score=0.0,
+    )
+
+    assert alert.obstacle_detected is True
+    assert alert.direction_hint == "center"
+    assert alert.min_depth == pytest.approx(0.08)
+
+
+def test_obstacle_alert_rejects_invalid_direction() -> None:
+    with pytest.raises(ValidationError):
+        ObstacleAlert(
+            frame_id=12,
+            timestamp=1746201234.567,
+            min_depth=0.1,
+            mean_center_depth=0.1,
+            obstacle_detected=True,
+            direction_hint="diagonal",  # not a valid literal
+            clearance_score=0.0,
+        )
+
+
+def test_obstacle_alert_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        ObstacleAlert(
+            frame_id=13,
+            timestamp=1746201234.567,
+            min_depth=0.5,
+            mean_center_depth=0.5,
+            obstacle_detected=False,
+            direction_hint="unknown",
+            clearance_score=1.0,
+            unknown_field="oops",
+        )

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,325 @@
+"""Tests for the post-flight building report generator."""
+
+from __future__ import annotations
+
+import pytest
+
+from breacheye.report import BuildingReport, FlightSummary, RoomSummary, ThreatSummary
+from breacheye.report_generator import ReportGenerator
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _make_flight(
+    *,
+    run_id: str = "run-test-001",
+    start_time: float = 1746200000.0,
+    end_time: float = 1746200120.0,
+    duration_s: float = 120.0,
+    frames_processed: int = 3600,
+    detections_total: int = 14,
+    nav_decisions_total: int = 240,
+    battery_start: int | None = 95,
+    battery_end: int | None = 72,
+) -> FlightSummary:
+    return FlightSummary(
+        run_id=run_id,
+        start_time=start_time,
+        end_time=end_time,
+        duration_s=duration_s,
+        frames_processed=frames_processed,
+        detections_total=detections_total,
+        nav_decisions_total=nav_decisions_total,
+        battery_start=battery_start,
+        battery_end=battery_end,
+    )
+
+
+def _make_threats(
+    *,
+    total_pois: int = 14,
+    by_category: dict | None = None,
+    by_threat_level: dict | None = None,
+    high_priority_items: list | None = None,
+) -> ThreatSummary:
+    return ThreatSummary(
+        total_pois=total_pois,
+        by_category=by_category or {"T1-01": 3, "T2-02": 2, "ROOM": 9},
+        by_threat_level=by_threat_level or {"HOT": 1, "WARM": 4, "CLEAR": 9},
+        high_priority_items=high_priority_items
+        or [
+            {
+                "id": "det-001",
+                "label": "Armed individual",
+                "threat_level": "HOT",
+                "location": "room-2",
+            }
+        ],
+    )
+
+
+_SENTINEL = object()
+
+
+def _make_report(
+    *,
+    rooms: list[RoomSummary] | object = _SENTINEL,
+    recommended_entry: str | None = "main-door",
+    chokepoints: list[str] | object = _SENTINEL,
+    narrative: str = "",
+) -> BuildingReport:
+    if rooms is _SENTINEL:
+        rooms = [
+            RoomSummary(
+                room_id="room-1",
+                poi_count=5,
+                threat_level="HOT",
+                coverage_pct=92.0,
+                entry_points=["main-door"],
+            ),
+            RoomSummary(
+                room_id="room-2",
+                poi_count=1,
+                threat_level="WARM",
+                coverage_pct=78.0,
+            ),
+        ]
+    if chokepoints is _SENTINEL:
+        chokepoints = ["hallway-junction-A"]
+    return BuildingReport(
+        report_id="rpt-test-abc",
+        generated_at=1746200200.0,
+        flight=_make_flight(),
+        rooms=rooms,  # type: ignore[arg-type]
+        threats=_make_threats(),
+        recommended_entry=recommended_entry,
+        chokepoints=chokepoints,  # type: ignore[arg-type]
+        narrative=narrative,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Section presence tests
+# --------------------------------------------------------------------------- #
+
+
+class TestGenerateTextReport:
+    def setup_method(self) -> None:
+        self.gen = ReportGenerator()
+
+    def test_header_section_present(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "BREACHEYE BUILDING ASSESSMENT REPORT" in output
+        assert "rpt-test-abc" in output
+
+    def test_flight_stats_section_present(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "FLIGHT STATS" in output
+        assert "run-test-001" in output
+        assert "120.0s" in output
+        assert "3600" in output
+        assert "14" in output
+        assert "240" in output
+
+    def test_battery_usage_displayed(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "95%" in output
+        assert "72%" in output
+
+    def test_threat_assessment_section_present(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "THREAT ASSESSMENT" in output
+        assert "Total POIs" in output
+        assert "HOT" in output
+        assert "WARM" in output
+
+    def test_high_priority_items_listed(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "Armed individual" in output
+        assert "HOT" in output
+
+    def test_room_summary_section_present(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "ROOM SUMMARY" in output
+        assert "room-1" in output
+        assert "room-2" in output
+
+    def test_room_entry_points_listed(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "main-door" in output
+
+    def test_recommendations_section_present(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert "RECOMMENDATIONS" in output
+        assert "main-door" in output
+        assert "hallway-junction-A" in output
+
+    def test_no_rooms_section_omitted(self) -> None:
+        report = _make_report(rooms=[])
+        output = self.gen.generate_text_report(report)
+        assert "ROOM SUMMARY" not in output
+
+    def test_no_narrative_section_omitted(self) -> None:
+        report = _make_report(narrative="")
+        output = self.gen.generate_text_report(report)
+        assert "NARRATIVE SUMMARY" not in output
+
+    def test_narrative_section_present_when_set(self) -> None:
+        report = _make_report(narrative="Alpha team should approach via the north corridor.")
+        output = self.gen.generate_text_report(report)
+        assert "NARRATIVE SUMMARY" in output
+        assert "Alpha team should approach via the north corridor." in output
+
+    def test_no_chokepoints_message(self) -> None:
+        report = _make_report(chokepoints=[])
+        output = self.gen.generate_text_report(report)
+        assert "none identified" in output
+
+    def test_no_recommended_entry_shows_na(self) -> None:
+        report = _make_report(recommended_entry=None)
+        output = self.gen.generate_text_report(report)
+        assert "N/A" in output
+
+    def test_battery_missing_gracefully(self) -> None:
+        flight = _make_flight(battery_start=None, battery_end=None)
+        report = BuildingReport(
+            report_id="rpt-nobatt",
+            generated_at=1746200200.0,
+            flight=flight,
+            threats=_make_threats(),
+        )
+        output = self.gen.generate_text_report(report)
+        assert "FLIGHT STATS" in output
+        assert "Battery" not in output
+
+    def test_battery_start_only(self) -> None:
+        flight = _make_flight(battery_start=80, battery_end=None)
+        report = BuildingReport(
+            report_id="rpt-startonly",
+            generated_at=1746200200.0,
+            flight=flight,
+            threats=_make_threats(),
+        )
+        output = self.gen.generate_text_report(report)
+        assert "80%" in output
+
+    def test_distance_estimate_displayed(self) -> None:
+        flight = FlightSummary(
+            run_id="run-x",
+            start_time=1746200000.0,
+            end_time=1746200060.0,
+            duration_s=60.0,
+            frames_processed=100,
+            detections_total=0,
+            nav_decisions_total=10,
+            distance_estimate_m=12.5,
+        )
+        report = BuildingReport(
+            report_id="rpt-dist",
+            generated_at=1746200200.0,
+            flight=flight,
+            threats=ThreatSummary(total_pois=0),
+        )
+        output = self.gen.generate_text_report(report)
+        assert "12.5" in output
+
+    def test_output_is_string(self) -> None:
+        output = self.gen.generate_text_report(_make_report())
+        assert isinstance(output, str)
+        assert len(output) > 0
+
+
+# --------------------------------------------------------------------------- #
+# Fallback narrative tests
+# --------------------------------------------------------------------------- #
+
+
+class TestFallbackNarrative:
+    def setup_method(self) -> None:
+        self.gen = ReportGenerator()
+
+    def test_fallback_contains_run_id(self) -> None:
+        report = _make_report()
+        narrative = self.gen._fallback_narrative(report)
+        assert "run-test-001" in narrative
+
+    def test_fallback_mentions_hot_threats(self) -> None:
+        report = _make_report()
+        narrative = self.gen._fallback_narrative(report)
+        assert "HOT" in narrative
+
+    def test_fallback_no_threats_message(self) -> None:
+        report = BuildingReport(
+            report_id="rpt-safe",
+            generated_at=1746200200.0,
+            flight=_make_flight(detections_total=0),
+            threats=ThreatSummary(
+                total_pois=0,
+                by_threat_level={"CLEAR": 5},
+            ),
+        )
+        narrative = self.gen._fallback_narrative(report)
+        assert "No high-priority threats" in narrative
+
+    def test_fallback_warm_only_message(self) -> None:
+        report = BuildingReport(
+            report_id="rpt-warm",
+            generated_at=1746200200.0,
+            flight=_make_flight(detections_total=3),
+            threats=ThreatSummary(
+                total_pois=3,
+                by_threat_level={"WARM": 3},
+            ),
+        )
+        narrative = self.gen._fallback_narrative(report)
+        assert "WARM" in narrative
+
+    def test_fallback_includes_recommended_entry(self) -> None:
+        report = _make_report(recommended_entry="back-door")
+        narrative = self.gen._fallback_narrative(report)
+        assert "back-door" in narrative
+
+    def test_fallback_includes_chokepoints(self) -> None:
+        report = _make_report(
+            recommended_entry=None,
+            chokepoints=["stairwell-B"],
+        )
+        narrative = self.gen._fallback_narrative(report)
+        assert "stairwell-B" in narrative
+
+    def test_fallback_room_count_included(self) -> None:
+        report = _make_report()
+        narrative = self.gen._fallback_narrative(report)
+        assert "2" in narrative or "two" in narrative.lower() or "area" in narrative
+
+    def test_fallback_returns_string(self) -> None:
+        narrative = self.gen._fallback_narrative(_make_report())
+        assert isinstance(narrative, str)
+        assert len(narrative) > 0
+
+
+# --------------------------------------------------------------------------- #
+# Async narrative tests (no Qwen available -> uses fallback)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_generate_narrative_without_qwen_uses_fallback() -> None:
+    """With no BREACHEYE_QWEN_SERVER_URL set, narrative falls back to rule-based."""
+    import os
+
+    gen = ReportGenerator()
+    report = _make_report()
+
+    # Ensure env var is not set
+    os.environ.pop("BREACHEYE_QWEN_SERVER_URL", None)
+
+    narrative = await gen.generate_narrative(report)
+
+    assert isinstance(narrative, str)
+    assert len(narrative) > 0
+    # Must contain content derived from the report data
+    assert "run-test-001" in narrative or "HOT" in narrative or "14" in narrative

--- a/tests/test_spatial_context.py
+++ b/tests/test_spatial_context.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from breacheye.rafa.schemas import BBox2D, DepthOutput, Detection, DetectionOutput, FrameInput
-from breacheye.rafa.spatial_context import build_spatial_context, summarize_spatial_context
+from breacheye.rafa.spatial_context import build_obstacle_alert, build_spatial_context, summarize_spatial_context
 
 
 def test_build_spatial_context_from_current_frame_outputs_frontier_and_objects() -> None:


### PR DESCRIPTION
## Summary

- **Depth proximity alerts (#72):** ObstacleAlert schema + publisher in rafa pipeline. Fires when depth shows obstacles close (< 0.15 threshold). Publishes on ZMQ 5556 alongside detections. Includes direction hint and clearance score.
- **Building report schema (#80):** BuildingReport, FlightSummary, RoomSummary, ThreatSummary Pydantic schemas.
- **Flight data accumulator (#78):** FlightDataAccumulator subscribes to bus events, deduplicates detections, tracks state transitions/battery/POI counts. Wired into HarnessRuntime with GET /report endpoint.
- **Post-flight report generator (#79):** ReportGenerator with text formatting + optional Qwen narrative. `breacheye report` CLI subcommand.

## Test plan

- [ ] 496/496 tests passing
- [ ] New tests: obstacle alert schema validation (4), building report schemas (10), flight data accumulator (19), report generator (26)
- [ ] `breacheye report` CLI works against running harness
- [ ] `breacheye calibrate` works in sim mode (verified)