### PR TITLE
feat: add clearance presets, adaptive threshold, and depth zone visualization

### DIFF
--- a/src/breacheye/rafa/orchestrator.py
+++ b/src/breacheye/rafa/orchestrator.py
@@ -66,6 +66,10 @@ class RafaPipeline:
         self._frames = {"detection": 0, "depth": 0, "decision": 0}
         self._recent_actions: list[NavigationAction] = []
         self._min_forward_clearance_m = _env_float("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", 0.45)
+        self._adaptive_threshold: "AdaptiveThreshold | None" = None
+        if os.environ.get("BREACHEYE_NAV_ADAPTIVE_CLEARANCE", "").lower() in ("1", "true", "yes"):
+            from breacheye.rafa.spatial_context import AdaptiveThreshold
+            self._adaptive_threshold = AdaptiveThreshold()
         self._search_tactic = NodeSearchTactic(
             clearance_threshold=self._min_forward_clearance_m,
             scan_degrees=_env_int("BREACHEYE_NAV_SEARCH_SCAN_DEGREES", 20, minimum=5, maximum=90),
@@ -242,6 +246,9 @@ class RafaPipeline:
         timings["depth_ms"] = _elapsed_ms(stage_started_at)
         if depth is not None:
             self._log_depth_artifact(depth)
+        if depth is not None and self._adaptive_threshold is not None:
+            self._min_forward_clearance_m = self._adaptive_threshold.update(depth)
+            self._search_tactic.clearance_threshold = self._min_forward_clearance_m
         stage_started_at = monotonic()
         navigation = await self._safe_navigation(frame, frame_meta, detection, depth)
         timings["navigation_ms"] = _elapsed_ms(stage_started_at)

--- a/src/breacheye/rafa/spatial_context.py
+++ b/src/breacheye/rafa/spatial_context.py
@@ -16,6 +16,147 @@ from breacheye.rafa.schemas import (
 )
 
 
+CLEARANCE_PRESETS: dict[str, float] = {
+    "tight": 0.25,    # Small rooms, tight corridors
+    "normal": 0.45,   # Default — typical indoor spaces
+    "wide": 0.65,     # Open areas, conservative flight
+}
+
+
+def resolve_clearance_threshold(explicit_value: float | None = None) -> float:
+    """Resolve clearance threshold from explicit value, preset, or env var.
+
+    Priority: explicit_value > BREACHEYE_NAV_CLEARANCE_PRESET > BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M > 0.45
+    """
+    if explicit_value is not None:
+        return max(0.0, min(1.0, explicit_value))
+
+    preset = os.environ.get("BREACHEYE_NAV_CLEARANCE_PRESET", "").lower()
+    if preset in CLEARANCE_PRESETS:
+        return CLEARANCE_PRESETS[preset]
+
+    try:
+        value = float(os.environ.get("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", 0.45))
+    except (TypeError, ValueError):
+        value = 0.45
+    return max(0.0, min(1.0, value))
+
+
+class AdaptiveThreshold:
+    """Adjusts clearance threshold based on recent depth statistics."""
+
+    def __init__(self, window_size: int = 30, hysteresis: int = 5) -> None:
+        self._window_size = window_size
+        self._hysteresis = hysteresis
+        self._base_threshold = resolve_clearance_threshold()
+        self._current = self._base_threshold
+        self._medians: list[float] = []
+        self._consecutive_agreement: int = 0
+        self._pending_preset: str | None = None
+
+    @property
+    def threshold(self) -> float:
+        return self._current
+
+    def update(self, depth: DepthOutput) -> float:
+        """Feed a depth frame, return current threshold."""
+        import numpy as np
+
+        try:
+            values = np.frombuffer(depth.depth_bytes, dtype=np.float32).reshape(depth.shape)
+            finite = values[np.isfinite(values)]
+            if finite.size == 0:
+                return self._current
+            median = float(np.median(finite))
+        except Exception:
+            return self._current
+
+        self._medians.append(median)
+        if len(self._medians) > self._window_size:
+            self._medians = self._medians[-self._window_size:]
+
+        # Determine suggested preset based on rolling median
+        rolling_median = sum(self._medians) / len(self._medians)
+        if rolling_median < 0.3:
+            suggested = "tight"
+        elif rolling_median > 0.6:
+            suggested = "wide"
+        else:
+            suggested = "normal"
+
+        # Hysteresis: require N consecutive frames agreeing before switching
+        if suggested == self._pending_preset:
+            self._consecutive_agreement += 1
+        else:
+            self._pending_preset = suggested
+            self._consecutive_agreement = 1
+
+        if self._consecutive_agreement >= self._hysteresis:
+            self._current = CLEARANCE_PRESETS[suggested]
+
+        return self._current
+
+
+def render_depth_zones(depth: DepthOutput, threshold: float = 0.45) -> bytes:
+    """Render depth frame with colored zone overlay. Returns JPEG bytes."""
+    import cv2
+    import numpy as np
+
+    values = np.frombuffer(depth.depth_bytes, dtype=np.float32).reshape(depth.shape)
+    height, width = values.shape
+
+    # Normalize depth to 0-255 grayscale
+    valid = values[np.isfinite(values)]
+    if valid.size == 0:
+        gray = np.zeros((height, width), dtype=np.uint8)
+    else:
+        normalized = np.clip((values - valid.min()) / max(valid.max() - valid.min(), 1e-6), 0, 1)
+        gray = (normalized * 255).astype(np.uint8)
+
+    # Convert to BGR for overlay
+    viz = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
+
+    # Color overlay per zone
+    margin = 0.1  # yellow band width
+    zones = {
+        "left": (slice(None), slice(0, width // 3)),
+        "center": (slice(None), slice(width // 3, (width * 2) // 3)),
+        "right": (slice(None), slice((width * 2) // 3, width)),
+    }
+
+    for name, (row_slice, col_slice) in zones.items():
+        zone_values = values[row_slice, col_slice]
+        finite = zone_values[np.isfinite(zone_values)]
+        if finite.size == 0:
+            continue
+        score = float(np.nanpercentile(finite, 20))
+
+        # Create overlay color
+        overlay = viz[row_slice, col_slice].copy()
+        if score < threshold:
+            # Red — blocked
+            overlay[:, :, 2] = np.clip(overlay[:, :, 2].astype(int) + 80, 0, 255).astype(np.uint8)
+        elif score < threshold + margin:
+            # Yellow — marginal
+            overlay[:, :, 1] = np.clip(overlay[:, :, 1].astype(int) + 60, 0, 255).astype(np.uint8)
+            overlay[:, :, 2] = np.clip(overlay[:, :, 2].astype(int) + 60, 0, 255).astype(np.uint8)
+        else:
+            # Green — clear
+            overlay[:, :, 1] = np.clip(overlay[:, :, 1].astype(int) + 60, 0, 255).astype(np.uint8)
+        viz[row_slice, col_slice] = overlay
+
+    # Draw zone boundary lines
+    cv2.line(viz, (width // 3, 0), (width // 3, height), (255, 255, 255), 1)
+    cv2.line(viz, ((width * 2) // 3, 0), ((width * 2) // 3, height), (255, 255, 255), 1)
+
+    # Add threshold text
+    cv2.putText(viz, f"threshold: {threshold:.2f}", (10, 25),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 1, cv2.LINE_AA)
+
+    _, jpeg = cv2.imencode(".jpg", viz, [cv2.IMWRITE_JPEG_QUALITY, 85])
+    return jpeg.tobytes()
+
+
 def build_spatial_context(
     *,
     meta: FrameInput,
@@ -116,12 +257,7 @@ def _bbox_relative_position(x1: int, x2: int, width: int | None) -> str:
 
 
 def _resolve_frontier_clearance(value: float | None) -> float:
-    if value is None:
-        try:
-            value = float(os.environ.get("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", 0.45))
-        except (TypeError, ValueError):
-            value = 0.45
-    return max(0.0, min(10.0, value))
+    return resolve_clearance_threshold(value)
 
 
 def compute_obstacle_alert(

--- a/tests/test_depth_threshold.py
+++ b/tests/test_depth_threshold.py
@@ -1,0 +1,154 @@
+import os
+import numpy as np
+import pytest
+from breacheye.rafa.schemas import DepthOutput
+from breacheye.rafa.spatial_context import (
+    CLEARANCE_PRESETS,
+    AdaptiveThreshold,
+    resolve_clearance_threshold,
+    render_depth_zones,
+)
+
+try:
+    import cv2 as _cv2  # noqa: F401
+    _CV2_AVAILABLE = True
+except ImportError:
+    _CV2_AVAILABLE = False
+
+cv2_required = pytest.mark.skipif(not _CV2_AVAILABLE, reason="cv2 not available")
+
+
+def _make_depth(values: np.ndarray) -> DepthOutput:
+    h, w = values.shape
+    return DepthOutput(
+        frame_id=0, timestamp=1.0, shape=(h, w),
+        depth_bytes=values.astype(np.float32).tobytes(),
+    )
+
+
+# --- P0: Preset tests ---
+
+def test_default_threshold():
+    """No env vars set → default 0.45."""
+    os.environ.pop("BREACHEYE_NAV_CLEARANCE_PRESET", None)
+    os.environ.pop("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", None)
+    assert resolve_clearance_threshold() == 0.45
+
+
+def test_preset_tight(monkeypatch):
+    monkeypatch.setenv("BREACHEYE_NAV_CLEARANCE_PRESET", "tight")
+    monkeypatch.delenv("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", raising=False)
+    assert resolve_clearance_threshold() == 0.25
+
+
+def test_preset_normal(monkeypatch):
+    monkeypatch.setenv("BREACHEYE_NAV_CLEARANCE_PRESET", "normal")
+    assert resolve_clearance_threshold() == 0.45
+
+
+def test_preset_wide(monkeypatch):
+    monkeypatch.setenv("BREACHEYE_NAV_CLEARANCE_PRESET", "wide")
+    assert resolve_clearance_threshold() == 0.65
+
+
+def test_explicit_overrides_preset(monkeypatch):
+    monkeypatch.setenv("BREACHEYE_NAV_CLEARANCE_PRESET", "wide")
+    assert resolve_clearance_threshold(0.30) == 0.30
+
+
+def test_env_var_overrides_default(monkeypatch):
+    monkeypatch.delenv("BREACHEYE_NAV_CLEARANCE_PRESET", raising=False)
+    monkeypatch.setenv("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", "0.55")
+    assert resolve_clearance_threshold() == 0.55
+
+
+def test_preset_takes_priority_over_env_var(monkeypatch):
+    monkeypatch.setenv("BREACHEYE_NAV_CLEARANCE_PRESET", "tight")
+    monkeypatch.setenv("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", "0.99")
+    assert resolve_clearance_threshold() == 0.25
+
+
+def test_unknown_preset_falls_through(monkeypatch):
+    monkeypatch.setenv("BREACHEYE_NAV_CLEARANCE_PRESET", "nonexistent")
+    monkeypatch.setenv("BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M", "0.55")
+    assert resolve_clearance_threshold() == 0.55
+
+
+def test_value_clamped():
+    assert resolve_clearance_threshold(5.0) == 1.0
+    assert resolve_clearance_threshold(-1.0) == 0.0
+
+
+# --- P1: Adaptive tests ---
+
+def test_adaptive_starts_at_base():
+    adaptive = AdaptiveThreshold()
+    assert adaptive.threshold == resolve_clearance_threshold()
+
+
+def test_adaptive_tightens_in_small_room():
+    """Low median depth → tight threshold after hysteresis."""
+    adaptive = AdaptiveThreshold(window_size=10, hysteresis=3)
+    values = np.full((100, 100), 0.2, dtype=np.float32)  # near
+    depth = _make_depth(values)
+    for _ in range(5):
+        adaptive.update(depth)
+    assert adaptive.threshold == CLEARANCE_PRESETS["tight"]
+
+
+def test_adaptive_widens_in_open_space():
+    """High median depth → wide threshold after hysteresis."""
+    adaptive = AdaptiveThreshold(window_size=10, hysteresis=3)
+    values = np.full((100, 100), 0.8, dtype=np.float32)  # far
+    depth = _make_depth(values)
+    for _ in range(5):
+        adaptive.update(depth)
+    assert adaptive.threshold == CLEARANCE_PRESETS["wide"]
+
+
+def test_adaptive_requires_hysteresis():
+    """Threshold doesn't change until hysteresis count met."""
+    adaptive = AdaptiveThreshold(window_size=10, hysteresis=5)
+    base = adaptive.threshold
+    values = np.full((100, 100), 0.2, dtype=np.float32)
+    depth = _make_depth(values)
+    # Feed 3 frames (less than hysteresis of 5)
+    for _ in range(3):
+        adaptive.update(depth)
+    assert adaptive.threshold == base  # hasn't switched yet
+
+
+def test_adaptive_handles_mixed_input():
+    """Alternating near/far doesn't trigger switch (no agreement)."""
+    adaptive = AdaptiveThreshold(window_size=10, hysteresis=3)
+    base = adaptive.threshold
+    near = _make_depth(np.full((100, 100), 0.1, dtype=np.float32))
+    far = _make_depth(np.full((100, 100), 0.9, dtype=np.float32))
+    for _ in range(10):
+        adaptive.update(near)
+        adaptive.update(far)
+    # Rolling median is ~0.5 → "normal", but hysteresis may not be met due to alternation
+    # The key assertion: it didn't swing to an extreme
+    assert adaptive.threshold in (CLEARANCE_PRESETS["normal"], base)
+
+
+# --- P2: Visualization tests ---
+
+@cv2_required
+def test_render_depth_zones_returns_jpeg():
+    """Verify render produces valid JPEG bytes."""
+    values = np.full((720, 960), 0.5, dtype=np.float32)
+    jpeg = render_depth_zones(_make_depth(values), threshold=0.45)
+    assert isinstance(jpeg, bytes)
+    assert len(jpeg) > 100
+    assert jpeg[:2] == b'\xff\xd8'  # JPEG magic bytes
+
+
+@cv2_required
+def test_render_depth_zones_with_blocked_center():
+    """Visualization with blocked center zone produces valid output."""
+    values = np.full((720, 960), 0.8, dtype=np.float32)
+    values[:, 320:640] = 0.1
+    jpeg = render_depth_zones(_make_depth(values), threshold=0.45)
+    assert isinstance(jpeg, bytes)
+    assert jpeg[:2] == b'\xff\xd8'


### PR DESCRIPTION
## Summary

**P0 — Clearance Presets:**
- `CLEARANCE_PRESETS`: tight (0.25), normal (0.45), wide (0.65)
- `resolve_clearance_threshold()` with priority chain: explicit value > `BREACHEYE_NAV_CLEARANCE_PRESET` env > `BREACHEYE_NAV_MIN_FORWARD_CLEARANCE_M` env > 0.45 default
- Unknown preset names fall through to env var / default
- Backward compatible: unchanged behavior when no preset set

**P1 — Adaptive Threshold:**
- `AdaptiveThreshold` class: rolling median over last 30 depth frames
- Room-size detection: median < 0.3 → tight, > 0.6 → wide, else normal
- Hysteresis: 5 consecutive frames must agree before switching
- Wired into orchestrator: `BREACHEYE_NAV_ADAPTIVE_CLEARANCE=1` enables it
- Dynamic value flows to obstacle alerts, spatial context, and search tactic

**P2 — Depth Zone Visualization:**
- `render_depth_zones()`: BGR overlay with red (blocked) / yellow (marginal) / green (clear) per zone
- Zone boundary lines and threshold label
- Returns JPEG bytes for debug artifacts

**Note:** Clamp upper bound corrected from 10.0 to 1.0 — depth is relative [0,1], the old 10.0 ceiling was unreachable.

Closes #74.

## Test plan
- [x] `pytest tests/test_depth_threshold.py tests/test_obstacle_alert.py tests/test_spatial_context.py -v` — 25 passed, 2 skipped (cv2 viz on headless server)
- [ ] `BREACHEYE_NAV_CLEARANCE_PRESET=tight breacheye demo --mode mock` — verify tighter avoidance
- [ ] `BREACHEYE_NAV_ADAPTIVE_CLEARANCE=1 breacheye demo --mode mock` — verify threshold adapts