### PR TITLE
fix: add command path instrumentation for flight debugging

### DIFF
--- a/src/breacheye/adapters/tello.py
+++ b/src/breacheye/adapters/tello.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 
 from breacheye.adapters.base import DroneAdapter, DroneState
+
+logger = logging.getLogger(__name__)
 
 
 class TelloAdapter(DroneAdapter):
@@ -81,6 +84,10 @@ class TelloAdapter(DroneAdapter):
         up_down: int,
         yaw: int,
     ) -> None:
+        logger.info(
+            "tello_call method=send_rc_control args=lr=%d fb=%d ud=%d yaw=%d",
+            left_right, forward_back, up_down, yaw,
+        )
         await self._call(
             "send_rc_control",
             left_right,
@@ -88,6 +95,7 @@ class TelloAdapter(DroneAdapter):
             up_down,
             yaw,
         )
+        logger.info("tello_ok method=send_rc_control")
 
     async def keepalive(self) -> None:
         # Some Tello firmware responds `unknown command: keepalive`; neutral RC
@@ -128,7 +136,15 @@ class TelloAdapter(DroneAdapter):
     async def _call(self, name: str, *args) -> None:
         if self._tello is None:
             raise RuntimeError("drone is not connected")
-        await asyncio.to_thread(getattr(self._tello, name), *args)
+        if name != "send_rc_control":
+            logger.info("tello_call method=%s args=%s", name, args)
+        try:
+            await asyncio.to_thread(getattr(self._tello, name), *args)
+        except Exception as exc:
+            logger.error("tello_error method=%s error=%s", name, str(exc))
+            raise
+        if name != "send_rc_control":
+            logger.info("tello_ok method=%s", name)
 
 
 def _int_or_none(value) -> int | None:

--- a/src/breacheye/safety.py
+++ b/src/breacheye/safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from time import monotonic
 
@@ -13,6 +14,8 @@ from breacheye.models import (
     DroneCommand,
     DroneTelemetry,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -101,6 +104,7 @@ class SafetyController:
         )
 
     async def _execute_locked(self, command: DroneCommand) -> None:
+        logger.info("cmd_execute id=%s type=%s", command.command_id, command.type)
         if command.type == CommandType.TAKEOFF:
             await self._preflight_takeoff()
             await self.adapter.takeoff()
@@ -108,6 +112,7 @@ class SafetyController:
             return
         if command.type == CommandType.LAND:
             if not await self._is_flying():
+                logger.warning("cmd_noop id=%s type=%s reason=not_flying", command.command_id, command.type)
                 return
             await self.adapter.land()
             return
@@ -116,6 +121,7 @@ class SafetyController:
             return
         if command.type == CommandType.HOVER:
             if not await self._is_flying():
+                logger.warning("cmd_noop id=%s type=%s reason=not_flying", command.command_id, command.type)
                 return
             await self.adapter.hover()
             return
@@ -123,16 +129,18 @@ class SafetyController:
             if not await self._is_flying():
                 raise RuntimeError("cannot rc_control while not flying")
             assert command.payload is not None
-            duration_ms = min(command.payload.duration_ms, self.config.max_rc_duration_ms)
+            raw_duration = command.payload.duration_ms
+            duration_ms = min(raw_duration, self.config.max_rc_duration_ms)
+            if duration_ms != raw_duration:
+                logger.info("cmd_duration_clamp original=%d clamped=%d", raw_duration, duration_ms)
             ttl_ms = command.ttl_ms or self.config.default_ttl_ms
             if duration_ms > ttl_ms:
                 raise ValueError("rc_control duration_ms cannot exceed command ttl_ms")
-            await self.adapter.rc_control(
-                self._clamp(command.payload.left_right),
-                self._clamp(command.payload.forward_back),
-                self._clamp(command.payload.up_down),
-                self._clamp(command.payload.yaw),
-            )
+            lr = self._clamp_log("left_right", command.payload.left_right)
+            fb = self._clamp_log("forward_back", command.payload.forward_back)
+            ud = self._clamp_log("up_down", command.payload.up_down)
+            yaw = self._clamp_log("yaw", command.payload.yaw)
+            await self.adapter.rc_control(lr, fb, ud, yaw)
             await asyncio.sleep(duration_ms / 1000)
             await self.adapter.hover()
             return
@@ -170,6 +178,12 @@ class SafetyController:
     def _clamp(self, value: int) -> int:
         limit = self.config.max_abs_velocity
         return max(-limit, min(limit, value))
+
+    def _clamp_log(self, axis: str, value: int) -> int:
+        clamped = self._clamp(value)
+        if clamped != value:
+            logger.info("cmd_clamp axis=%s original=%d clamped=%d", axis, value, clamped)
+        return clamped
 
     async def _watchdog_loop(self) -> None:
         while not self._closed:

--- a/src/breacheye/service.py
+++ b/src/breacheye/service.py
@@ -281,6 +281,7 @@ def create_app(
 
     @app.post("/commands")
     async def command(command: DroneCommand):
+        log.info("cmd_received id=%s type=%s issued_by=%s", command.command_id, command.type, command.issued_by)
         try:
             result = await runtime.safety.execute(command)
             await runtime.sync_fsm_after_command(command, result)


### PR DESCRIPTION
## Summary

- Adds `cmd_received` log in `/commands` endpoint before commands hit SafetyController
- Adds `cmd_execute`, `cmd_noop`, `cmd_clamp`, and `cmd_duration_clamp` logs in `SafetyController._execute_locked`
- Adds `tello_call`, `tello_ok`, and `tello_error` logs in `TelloAdapter._call` and `rc_control`

All messages use `key=value` format for grep-friendly filtering. No behavior changes — pure instrumentation.

## Test plan

- [ ] Verify `cmd_received` fires on POST /commands in service logs
- [ ] Send a LAND/HOVER command while grounded — confirm `cmd_noop reason=not_flying` appears
- [ ] Send an RC_CONTROL with velocity > 35 — confirm `cmd_clamp` shows original/clamped values
- [ ] Send an RC_CONTROL with duration_ms > 1000 — confirm `cmd_duration_clamp` appears
- [ ] Run in tello mode — confirm `tello_call method=takeoff` and `tello_ok method=takeoff` bracket the SDK call
- [ ] Verify no duplicate error logs for `send_rc_control` failures